### PR TITLE
Support for creating Maven distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ Geode includes the following features:
 
 # Geode in 5 minutes
 
-Obtain the source archive from Pivotal.  Extract and build from source (note: currently Geode supports jdk1.7.75):
+Extract and build from source (note: currently Geode supports jdk1.7.75):
 
     $ cd geode
     $ ./gradlew build installDist
 
 Start a locator and server:
 
-    $ cd gemfire-assembly/build/install/geode
+    $ cd gemfire-assembly/build/install/apache-geode
     $ ./bin/gfsh
     gfsh> start locator --name=locator
     gfsh> start server --name=server

--- a/RUNNING.txt
+++ b/RUNNING.txt
@@ -4,7 +4,7 @@ Create a distribution archive using
 
 Unpack the archive found in gemfire-assembly/build/distributions and run the gfsh shell
 
-cd apache-gemfire-*
+cd apache-geode-*
 bin/gfsh
 
 OR

--- a/build.gradle
+++ b/build.gradle
@@ -26,10 +26,12 @@ allprojects {
     buildDir = buildRoot + project.path.replace(":", "/") + "/build"
   }
 
-  tasks.withType(Tar){
-    compression = Compression.GZIP
-    extension = 'tar.gz'
-  }
+  gradle.taskGraph.whenReady( { graph ->
+    tasks.withType(Tar).each { tar ->
+      tar.compression = Compression.GZIP
+      tar.extension = 'tar.gz'
+    }
+  })
 }
 
 def testResultsDir(def parent, def name) {

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ allprojects {
     maven { url "http://dist.gemstone.com/maven/release" }
   }
 
-  group = "io.pivotal.gemfire"
+  group = "org.apache.geode"
 
   apply plugin: 'idea'
   apply plugin: 'eclipse'
@@ -24,6 +24,11 @@ allprojects {
   buildRoot = buildRoot.trim()
   if (!buildRoot.isEmpty()) {
     buildDir = buildRoot + project.path.replace(":", "/") + "/build"
+  }
+
+  tasks.withType(Tar){
+    compression = Compression.GZIP
+    extension = 'tar.gz'
   }
 }
 

--- a/gemfire-assembly/build.gradle
+++ b/gemfire-assembly/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'distribution'
+apply plugin: 'maven-publish'
 
 jar.enabled = false
 
@@ -116,7 +117,7 @@ task gfshDepsJar (type: Jar, dependsOn: ':gemfire-core:classes') {
 
 distributions {
   main {
-    baseName = 'geode' //TODO rootProject.name
+    baseName = 'apache-geode' //TODO rootProject.name
     contents {
       duplicatesStrategy 'exclude'
       
@@ -143,6 +144,10 @@ distributions {
         from project(":gemfire-joptsimple").configurations.archives.allArtifacts.files
 
         from project(":gemfire-core").configurations.runtime
+        // Copying from provided configuration is only for supporting Spring Data GemFire.
+        // If there are more dependencies added to provided configuration, this will need
+        // to change
+        from project(":gemfire-core").configurations.provided
         from project(":gemfire-core").configurations.archives.allArtifacts.files
 
         // include this jar        
@@ -163,6 +168,63 @@ distributions {
       }
     }
   }
+}
+
+
+// Repos to be added to POMs
+def springReleaseRepo = [ id:'spring-release', name:'Spring Maven RELEASE Repository', url:'https://repo.spring.io/release' ]
+def springMilestoneRepo = [ id:'spring-milestone', name:'Spring Maven MILESTONE Repository', url:'https://repo.spring.io/milestone' ]
+def springSnapshotRepo = [ id:'spring-snapshot', name:'Spring Maven SNAPSHOT Repository', url:'https://repo.spring.io/snapshot' ]
+def springLibsReleaseRepo = [ id:'libs-release', name:'Spring Maven libs-release Repository', url:'http://repo.spring.io/libs-release' ]
+def springExtReleaseLocalRepo = [ id:'ext-release-local', name:'Spring Maven ext-release-local Repository', url:'http://repo.spring.io/ext-release-local' ]
+
+def MavenRepos = [ springReleaseRepo, springSnapshotRepo, springLibsReleaseRepo, springExtReleaseLocalRepo ]
+
+// Jars to be published via Maven
+def coreJar = [publicationName:'coreJar', project:project(":gemfire-core").name]
+def jgroupsJar = [publicationName:'jgroupsJar', project:project(":gemfire-jgroups").name]
+def jsonJar = [publicationName:'jsonJar', project:project(":gemfire-json").name]
+def joptsimpleJar = [publicationName:'joptsimpleJar', project:project(":gemfire-joptsimple").name]
+def MavenJars = [ coreJar, jgroupsJar, jsonJar, joptsimpleJar ]
+
+afterEvaluate {
+  publishing {
+    publications {
+      MavenJars.each {
+        def publicationName = it.publicationName
+        def projectName = it.project
+        "$publicationName"(MavenPublication) {
+          artifactId projectName
+          artifact project(':' + projectName).jar
+          pom.withXml {
+            def repositoriesNode = asNode().appendNode('repositories')
+            MavenRepos.each {
+              def repositoryNode = repositoriesNode.appendNode('repository')
+              repositoryNode.appendNode('id', it.id)
+              repositoryNode.appendNode('name', it.name)
+              repositoryNode.appendNode('url', it.url)
+            }
+            def dependenciesNode = asNode().appendNode('dependencies')
+            //Iterate over the runtime dependencies
+            project(':' + projectName).configurations.runtime.allDependencies.each {
+              def dependencyNode = dependenciesNode.appendNode('dependency')
+              dependencyNode.appendNode('groupId', it.group)
+              dependencyNode.appendNode('artifactId', it.name)
+              dependencyNode.appendNode('version', it.version)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  publishing {
+    repositories {
+      maven {
+        url "$buildDir/repo"
+      }
+    }
+  } 
 }
 
 artifacts {

--- a/gemfire-assembly/build.gradle
+++ b/gemfire-assembly/build.gradle
@@ -147,7 +147,9 @@ distributions {
         // Copying from provided configuration is only for supporting Spring Data GemFire.
         // If there are more dependencies added to provided configuration, this will need
         // to change
-        from project(":gemfire-core").configurations.provided
+        from (project(":gemfire-core").configurations.provided) {
+          include 'spring-data-gemfire-*'
+        }
         from project(":gemfire-core").configurations.archives.allArtifacts.files
 
         // include this jar        

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 1.0.0.0-SNAPSHOT
+version = 1.0.0-incubating-SNAPSHOT
 org.gradle.daemon = true
 org.gradle.jvmargs = -Xmx2048m
 


### PR DESCRIPTION
- Modified groupId to 'org.apache.geode'
- Modified distribution name to 'apache-geode'
- Modified version to include 'incubating'
- Updated README.md and RUNNING.txt with new directory name
- Added 'maven-publish' plugin for creating Maven distribution

Create Maven distribution: clean build publish
Install artifacts to local Maven repo: publishToMavenLocal

Tested by using Maven artifacts in a sample application which created a cache.