### PR TITLE
Handle region create/destroy remote event in Redis adpater

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/redis/ExecutionHandlerContext.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/redis/ExecutionHandlerContext.java
@@ -22,6 +22,7 @@ import com.gemstone.gemfire.cache.TransactionException;
 import com.gemstone.gemfire.cache.TransactionId;
 import com.gemstone.gemfire.cache.UnsupportedOperationInTransactionException;
 import com.gemstone.gemfire.cache.query.QueryInvocationTargetException;
+import com.gemstone.gemfire.cache.query.RegionNotFoundException;
 import com.gemstone.gemfire.internal.redis.executor.transactions.TransactionExecutor;
 import com.gemstone.gemfire.redis.GemFireRedisServer;
 
@@ -213,7 +214,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
         return;
       } catch (Exception e) {
         cause = e;
-        if (e instanceof RegionDestroyedException || e.getCause() instanceof QueryInvocationTargetException)
+        if (e instanceof RegionDestroyedException || e instanceof RegionNotFoundException || e.getCause() instanceof QueryInvocationTargetException)
           Thread.sleep(WAIT_REGION_DSTRYD_MILLIS);
       }
     }

--- a/gemfire-core/src/test/java/com/gemstone/gemfire/redis/RedisDistDUnitTest.java
+++ b/gemfire-core/src/test/java/com/gemstone/gemfire/redis/RedisDistDUnitTest.java
@@ -26,6 +26,8 @@ public class RedisDistDUnitTest extends CacheTestCase {
 
   private int server1Port;
   private int server2Port;
+  
+  private static final int JEDIS_TIMEOUT = 20 * 1000;
 
   private abstract class ClientTestBase extends SerializableCallable {
 
@@ -81,8 +83,8 @@ public class RedisDistDUnitTest extends CacheTestCase {
   }
 
   public void testConcListOps() throws Throwable {
-    final Jedis jedis1 = new Jedis("localhost", server1Port, 10000);
-    final Jedis jedis2 = new Jedis("localhost", server2Port, 10000);
+    final Jedis jedis1 = new Jedis("localhost", server1Port, JEDIS_TIMEOUT);
+    final Jedis jedis2 = new Jedis("localhost", server2Port, JEDIS_TIMEOUT);
     final int pushes = 20;
     class ConcListOps extends ClientTestBase {
       protected ConcListOps(int port) {
@@ -91,7 +93,7 @@ public class RedisDistDUnitTest extends CacheTestCase {
 
       @Override
       public Object call() throws Exception {
-        Jedis jedis = new Jedis("localhost", port, 10000);
+        Jedis jedis = new Jedis("localhost", port, JEDIS_TIMEOUT);
         Random r = new Random();
         for (int i = 0; i < pushes; i++) {
           if (r.nextBoolean()) {
@@ -114,8 +116,9 @@ public class RedisDistDUnitTest extends CacheTestCase {
     assertEquals(result1, result2);
   }
 
-
   public void testConcCreateDestroy() throws Throwable {
+    addExpectedException("RegionDestroyedException");
+    addExpectedException("IndexInvalidException");
     final int ops = 40;
     final String hKey = TEST_KEY+"hash";
     final String lKey = TEST_KEY+"list";
@@ -129,7 +132,7 @@ public class RedisDistDUnitTest extends CacheTestCase {
 
       @Override
       public Object call() throws Exception {
-        Jedis jedis = new Jedis("localhost", port, 10000);
+        Jedis jedis = new Jedis("localhost", port, JEDIS_TIMEOUT);
         Random r = new Random();
         for (int i = 0; i < ops; i++) {
           int n = r.nextInt(4);
@@ -189,7 +192,7 @@ public class RedisDistDUnitTest extends CacheTestCase {
 
       @Override
       public Object call() throws Exception {
-        Jedis jedis = new Jedis("localhost", port, 10000);
+        Jedis jedis = new Jedis("localhost", port, JEDIS_TIMEOUT);
         Random r = new Random();
         for (int i = 0; i < ops; i++) {
           int n = r.nextInt(4);


### PR DESCRIPTION
Ignore events where region creation initiated remotely attempts to create a local region reference when the region has already been destroyed. Also, the destruction of a region may be caught by the query engine, so I have accounted for that by handling com.gemstone.gemfire.cache.query.RegionNotFoundException. Finally, the Jedis client timeout has been increased for RedisDistDunitTest to account for concurrent region creation/destruction.