### PR TITLE
Wrong one line build command

### DIFF
--- a/gemfire-spark-connector/doc/1_building.md
+++ b/gemfire-spark-connector/doc/1_building.md
@@ -7,8 +7,10 @@ You will need Scala 2.10 and sbt 0.13.5 to 0.13.7.
 To build against Apache Geode, you need to build Geode first and publish the jars
 to local repository. In the root of Geode directory, run:
 
+```
 ./gradlew clean build -Dskip.tests=true
 ./gradlew publishToMavenLocal
+```
 
 In the root directory of connector project, run:
 ```


### PR DESCRIPTION
How to build Geode in Spark Connector document seems odd.
It should be 2 lines but it is combined into one line.