### PR TITLE
GEODE-537 Fix NPE in AFTER_COMPLETION processing during JTA transaction rollback

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/tier/sockets/command/CommitCommand.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/tier/sockets/command/CommitCommand.java
@@ -119,7 +119,9 @@ public class CommitCommand extends BaseCommand {
     responseMsg.setMessageType(MessageType.RESPONSE);
     responseMsg.setTransactionId(origMsg.getTransactionId());
     responseMsg.setNumberOfParts(1);
-    response.setClientVersion(servConn.getClientVersion());
+    if( response != null ) {
+    	response.setClientVersion(servConn.getClientVersion());
+    }
     responseMsg.addObjPart(response, zipValues);
     servConn.getCache().getCancelCriterion().checkCancelInProgress(null);
     if (logger.isDebugEnabled()) {

--- a/gemfire-core/src/test/java/com/gemstone/gemfire/internal/cache/tier/sockets/command/CommitCommandTest.java
+++ b/gemfire-core/src/test/java/com/gemstone/gemfire/internal/cache/tier/sockets/command/CommitCommandTest.java
@@ -1,0 +1,39 @@
+package com.gemstone.gemfire.internal.cache.tier.sockets.command;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.gemstone.gemfire.CancelCriterion;
+import com.gemstone.gemfire.cache.Cache;
+import com.gemstone.gemfire.internal.cache.tier.sockets.Message;
+import com.gemstone.gemfire.internal.cache.tier.sockets.ServerConnection;
+
+public class CommitCommandTest {
+
+	/**
+	 * Test for GEODE-537
+	 * No NPE should be thrown from the {@link CommitCommand.writeCommitResponse()}
+	 * if the response message is null as it is the case when JTA
+	 * transaction is rolled back with TX_SYNCHRONIZATION AFTER_COMPLETION STATUS_ROLLEDBACK 
+	 * @throws IOException 
+	 * 
+	 */
+	@Test
+	public void testWriteNullResponse() throws IOException {
+		
+		Cache cache = mock(Cache.class);
+		Message origMsg = mock(Message.class);
+		ServerConnection servConn = mock(ServerConnection.class);
+		when(servConn.getResponseMessage()).thenReturn(mock(Message.class));
+		when(servConn.getCache()).thenReturn(cache);
+		when(cache.getCancelCriterion()).thenReturn(mock(CancelCriterion.class));
+		
+		CommitCommand.writeCommitResponse(null, origMsg, servConn);
+		
+	}
+	
+}


### PR DESCRIPTION
A fix for the NullPointerException thrown in TX_SYNCHRONIZATION command processing of AFTER_COMPLETION event during JTA transaction rollback.