### PR TITLE
GEODE-655 Website sentence needs improvement

### DIFF
--- a/gemfire-site/website/content/index.html
+++ b/gemfire-site/website/content/index.html
@@ -8,7 +8,7 @@ title: Performance is key. Consistency is a must.
             <img class="logo-title img-responsive hidden-xs" src="img/apache_geode_logo.png" />
             <div class="text-container">
                 <h2 class="tagline"><em>Performance</em> is key. <em>Consistency</em> is a must.</h2>
-                <p class="description">Solving low latency data management problems at very high concurrency since 2002.<br/>
+                <p class="description">Providing low latency, high concurrency data management solutions since 2002.<br/>
                   <br/>Build high-speed, data-intensive applications that elastically meet performance requirements at any scale.<br/>
                   Take advantage of Apache Geode's unique technology that blends advanced techniques for data replication, partitioning and distributed processing.
 


### PR DESCRIPTION
The first sentence on the http://geode.incubator.apache.org/ web page means something different than intended. The sentence says
"Solving low latency data management problems at very high concurrency since 2002."

Low latency modifies data management problems. Because of this, the sentence implies that the problems being solved are ones that exhibit low latency. This is the opposite of what is intended.

This pull request implements a better wording for that sentence:
Providing low latency, high concurrency data management solutions since 2002.