### PR TITLE
GEODE-568: SharedConfiguration region scope needs to be DISTRIBUTED_A…

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/SharedConfiguration.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/distributed/internal/SharedConfiguration.java
@@ -646,6 +646,7 @@ public class SharedConfiguration {
         regionAttrsFactory.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
         regionAttrsFactory.setCacheListener(new ConfigurationChangeListener(this));
         regionAttrsFactory.setDiskStoreName(CLUSTER_CONFIG_DISK_STORE_NAME);
+        regionAttrsFactory.setScope(Scope.DISTRIBUTED_ACK);
         InternalRegionArguments internalArgs = new InternalRegionArguments();
         internalArgs.setIsUsedForMetaRegion(true);
         internalArgs.setMetaRegionWithTransactions(false);


### PR DESCRIPTION
…CK to make sure update events will fire in the correct order.