### PR TITLE
Enabling direct reporting on Geode's website

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,8 @@
     <!-- Loading Typekit -->
     <script type="text/javascript" src="//use.typekit.net/ddl7izx.js"></script>
     <script type="text/javascript">try{Typekit.load();}catch(e){}</script>
+    <!-- Enabling Issue collector -->
+    <script type="text/javascript" src="https://issues.apache.org/jira/s/bfe7c1e06d911e53fc96873d31176352-T/en_UK-ugtin9/6332/81/1.4.15/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-UK&collectorId=2e0eeb8d"></script>
     <!-- Place this tag right after the last button or just before your close body tag. -->
     <script async defer id="github-bjs" src="https://buttons.github.io/buttons.js"></script>
         <!-- Loading Bootstrap -->


### PR DESCRIPTION
This enables the vertical widget on the right hand side of the website similar to what's available on CouchDB's website http://couchdb.apache.org/
