### PR TITLE
GEODE-712: Move junit asserts out of finally block

### DIFF
--- a/gemfire-core/src/test/java/com/gemstone/gemfire/internal/offheap/SimpleMemoryAllocatorJUnitTest.java
+++ b/gemfire-core/src/test/java/com/gemstone/gemfire/internal/offheap/SimpleMemoryAllocatorJUnitTest.java
@@ -217,13 +217,13 @@ public class SimpleMemoryAllocatorJUnitTest {
         assertFalse(listener.isClosed());
         assertFalse(stats2.isClosed());
         stats = stats2;
-      } finally {
         ma.close();
         assertTrue(listener.isClosed());
         assertFalse(stats.isClosed());
+      } finally {
         SimpleMemoryAllocatorImpl.freeOffHeapMemory();
-        assertTrue(stats.isClosed());
       }
+      assertTrue(stats.isClosed());
     }
   }
   @Test


### PR DESCRIPTION
This change prevents the assert in the finally block from "swallowing" the thrown exception.
The next time this test fails, we can reopen GEODE-712.