### PR TITLE
GEODE-601: Fix intermittent exception in DiskRegionJUnitTest.

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskStoreImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DiskStoreImpl.java
@@ -368,7 +368,7 @@ public class DiskStoreImpl implements DiskStore {
    */
   private DiskStoreID diskStoreID;
 
-  final CountDownLatch _testHandleDiskAccessException = new CountDownLatch(1);
+  private final CountDownLatch _testHandleDiskAccessException = new CountDownLatch(1);
   
   private final ThreadPoolExecutor diskStoreTaskPool;
   
@@ -2311,7 +2311,7 @@ public class DiskStoreImpl implements DiskStore {
     close(false);
   }
 
-  void waitForClose() {
+  protected void waitForClose() {
     if (diskException.get() != null) {
       try {
         _testHandleDiskAccessException.await();

--- a/gemfire-core/src/test/java/com/gemstone/gemfire/internal/cache/Bug39079DUnitTest.java
+++ b/gemfire-core/src/test/java/com/gemstone/gemfire/internal/cache/Bug39079DUnitTest.java
@@ -356,7 +356,7 @@ public class Bug39079DUnitTest extends CacheTestCase {
     assertNotNull(gemfirecache);
   }
   
-  private static void validateRuningBridgeServerList() throws Exception{
+  private static void validateRuningBridgeServerList(){
     /*Region region = gemfirecache.getRegion(Region.SEPARATOR + REGION_NAME);
     assertNotNull(region);*/
     try {        
@@ -374,7 +374,7 @@ public class Bug39079DUnitTest extends CacheTestCase {
         fail("test failed due to ", e);
       }
       
-      ((LocalRegion)region).getDiskRegion().getDiskStore()._testHandleDiskAccessException.await();
+      ((LocalRegion) region).getDiskStore().waitForClose();
       assertTrue(region.getRegionService().isClosed());
       
       region = null;

--- a/gemfire-core/src/test/java/com/gemstone/gemfire/internal/cache/DiskRegionTestingBase.java
+++ b/gemfire-core/src/test/java/com/gemstone/gemfire/internal/cache/DiskRegionTestingBase.java
@@ -134,7 +134,6 @@ public class DiskRegionTestingBase
       if (cache != null && !cache.isClosed()) {
         for (Iterator itr = cache.rootRegions().iterator(); itr.hasNext();) {
           Region root = (Region)itr.next();
-//          String name = root.name.getMethodName();
           if(root.isDestroyed() || root instanceof HARegion) {
             continue;
           }


### PR DESCRIPTION
An expected DiskAccessException causes the cache to close
asynchronously. That leads to a race condition during test tearDown,
between checking that the cache is closed and it's access. Now wait
for the cache to close before tearDown.
Refactors:
 Moved putSuccessful and exceptionOccurred inside Puts
 Remove unnecessary thread creation for Puts in DiskRegionJUnitTest
 Expose _testHandleDiskAccessException through method