### PR TITLE
Fixes GEODE-874

### DIFF
--- a/COMPILING.txt
+++ b/COMPILING.txt
@@ -1,22 +1,22 @@
 To build with gradle, just run
 
-./gradlew build
+./gradle build
 
 This will create the binary artifacts and run all of the tests but 
 if for some reason you want to skip running the tests include -Dskip.tests=true on the gradle invocation. For example:
 
-./gradlew build -Dskip.tests=true
+./gradle build -Dskip.tests=true
 
 To create a distribution run
 
-./gradlew distTar
+./gradle distTar
 
 or
 
-./gradlew distZip
+./gradle distZip
 
 the distribution archives will be located in gemfire-assembly/build/distributions/.
 
 To create an unzipped distribution run
 
-./gradlew installDist
+./gradle installDist

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ _HelloWorld.java_
 
 Compile and run `HelloWorld.java`.  The classpath should include `gemfire-core-dependencies.jar`.
 
-    javac -cp /some/path/geode/gemfire-assembly/build/install/geode/lib/gemfire-core-dependencies.jar HelloWorld.java
-    java -cp .:/some/path/geode/gemfire-assembly/build/install/geode/lib/gemfire-core-dependencies.jar HelloWorld
+    javac -cp /some/path/geode/gemfire-assembly/build/install/apache-geode/lib/gemfire-core-dependencies.jar HelloWorld.java
+    java -cp .:/some/path/geode/gemfire-assembly/build/install/apache-geode/lib/gemfire-core-dependencies.jar HelloWorld
 
 #Application Development
 

--- a/RUNNING.txt
+++ b/RUNNING.txt
@@ -1,6 +1,6 @@
 Create a distribution archive using
 
-./gradlew distTar
+./gradle distTar
 
 Unpack the archive found in gemfire-assembly/build/distributions and run the gfsh shell
 
@@ -11,7 +11,7 @@ OR
 
 Unpack the archive using Gradle task
 
-./gradlew installDist
+./gradle installDist
 
 cd build/install/gemfire
 bin/gfsh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,7 @@ LABEL version=unstable
 
 RUN	git clone -b develop https://github.com/apache/incubator-geode.git \
 	&& cd incubator-geode \
-	&& ./gradlew build -Dskip.tests=true \
+	&& ./gradle build -Dskip.tests=true \
 	&& ls /incubator-geode | grep -v gemfire-assembly | xargs rm -rf \
 	&& rm -rf /root/.gradle/ \
 	&& rm -rf /incubator-geode/gemfire-assembly/build/distributions/ \

--- a/gemfire-spark-connector/doc/1_building.md
+++ b/gemfire-spark-connector/doc/1_building.md
@@ -8,8 +8,8 @@ To build against Apache Geode, you need to build Geode first and publish the jar
 to local repository. In the root of Geode directory, run:
 
 ```
-./gradlew clean build -Dskip.tests=true
-./gradlew publishToMavenLocal
+./gradle clean build -Dskip.tests=true
+./gradle publishToMavenLocal
 ```
 
 In the root directory of connector project, run:


### PR DESCRIPTION
Replaced gradlew commands with gradle in text files.
Corrected classpath shown for compiling and running app in Geode in 5
Minutes section of README.md