### PR TITLE
GEODE-893: CI failure: LauncherLifecycleCommandsJUnitTest.testGetSpringJars

### DIFF
--- a/gemfire-assembly/src/test/java/com/gemstone/gemfire/management/internal/cli/commands/LauncherLifecycleCommandsJUnitTest.java
+++ b/gemfire-assembly/src/test/java/com/gemstone/gemfire/management/internal/cli/commands/LauncherLifecycleCommandsJUnitTest.java
@@ -348,9 +348,9 @@ public class LauncherLifecycleCommandsJUnitTest {
 
     assertTrue(String.format("Expected empty; but was (%1$s)", expectedSpringJarNames),
         expectedSpringJarNames.isEmpty());
-    assertEquals(3212, springCoreVersion);
+    assertEquals(424, springCoreVersion);
     assertEquals(191, springDataCommonsVersion);
-    assertEquals(151, springDataGemFireVersion);
+    assertEquals(172, springDataGemFireVersion);
   }
 
   @Test


### PR DESCRIPTION
Updated JUNIT to assert appropriate Spring and SDG versions.