### PR TITLE
GEODE-906: Clean up source header / modification text

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -19,3 +19,6 @@ This product also includes code adapted from:
 
 Apache Solr (http://lucene.apache.org/solr/)
 Copyright 2014 The Apache Software Foundation
+
+fastutil
+Copyright (C) 2002-2014 Sebastiano Vigna 

--- a/geode-core/src/main/java/com/gemstone/gemfire/cache/query/internal/index/HashIndexSet.java
+++ b/geode-core/src/main/java/com/gemstone/gemfire/cache/query/internal/index/HashIndexSet.java
@@ -19,19 +19,6 @@
  * insertionIndex(), index(), trimToSize() are based on code provided by fastutil
  * They are based from add(), contains() and other methods from ObjectOpenHashSet
  * We have used the traversing mechanism and the HashCommon.mix()
- * Copyright (C) 2002-2014 Sebastiano Vigna 
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License. 
  */
 package com.gemstone.gemfire.cache.query.internal.index;
 

--- a/geode-core/src/main/java/com/gemstone/gemfire/internal/cache/IdentityArrayList.java
+++ b/geode-core/src/main/java/com/gemstone/gemfire/internal/cache/IdentityArrayList.java
@@ -1,9 +1,4 @@
 /*
- * This is a modified version of the fastutil ObjectArrayList.  It is modified
- * to use identity checks rather than equality checks for higher performance.
- * 
- * The original file had this Apache 2.0 copyright:
- * 
  * Copyright (C) 2002-2014 Sebastiano Vigna 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +12,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License. 
+ */
+
+/*
+ * This is a modified version of the fastutil ObjectArrayList.  It is modified
+ * to use identity checks rather than equality checks for higher performance.
  */
 package com.gemstone.gemfire.internal.cache;
 import java.util.Arrays;


### PR DESCRIPTION
* HashIndexSet to use the standard Apache source header with a separate modification statement
* IdentityArrayList to use the original license header with a separate modificaiton statement
* Added fastutil copyright to the NOTICE