### PR TITLE
GEODE-36 Interim fix to display correct product name on gfsh cli

### DIFF
--- a/geode-core/src/main/java/com/gemstone/gemfire/management/internal/cli/shell/Gfsh.java
+++ b/geode-core/src/main/java/com/gemstone/gemfire/management/internal/cli/shell/Gfsh.java
@@ -506,7 +506,7 @@ public class Gfsh extends JLineShell {
   }
 
   public String getWelcomeMessage() {
-    return ansiHandler.decorateString("Monitor and Manage GemFire", ANSIStyle.CYAN);
+    return ansiHandler.decorateString("Monitor and Manage " + GemFireVersion.getProductName(), ANSIStyle.CYAN);
   }
 
   //Over-ridden to avoid default behavior which is:


### PR DESCRIPTION
Simple text change which should now be configurable from gradle settings file.
This is an interim fix to display the correct product name on gfsh cli.
