### PR TITLE
Geode-54: missing javadocs

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -234,7 +234,7 @@
         <nav class="collapse navbar-collapse bf-navbar-collapse" role="navigation">
             <ul class="nav navbar-nav navbar-right">
                 <li class="active"><a href="/community/"><span class="icns icon-group"></span></a></li>
-                <li><a href="http://geode.docs.pivotal.io" target="_blank"><span class="icns icon-book"></span></a></li>
+                <li class=""><a href="/docs/"><span class="icns icon-book"></span></a></li>
                 <li><a href="http://github.com/apache/incubator-geode" target="_blank"><span class="icns icon-github-sign"></span></a></li>
                 <!--<li><a href="https://trello.com/b/exQmJIOn/usergrid" target="_blank"><span class="icns icon-trello"></span></a></li>-->
                 <li><a href="https://issues.apache.org/jira/browse/GEODE/"
@@ -249,8 +249,6 @@
         </nav>
     </div>
     </header>
-
-
 
 
 <!-- Licensed to the Apache Software Foundation (ASF) under one
@@ -383,7 +381,7 @@ under the License. -->
       </div>
       <div class="col-md-3">
         	<h3><a target="_blank" href="https://www.youtube.com/channel/UCaY2q0UlWjAgEGL7uhCLs6A">Geode ClubHouse</a></h3>
-        	<p>We meet every 15 days online for discussions around specific features, detailing internals and discuss on-going issues on JIRA at the Geode Clubhouse. All meetings are recorded and videos are availabe in our <a href="https://www.youtube.com/channel/UCaY2q0UlWjAgEGL7uhCLs6A">YouTube</a> channel.<p>
+        	<p>We meet every 15 days online for discussions around specific features, detailing internals and discuss on-going issues on JIRA at the Geode Clubhouse. All meetings are recorded and videos are available in our <a href="https://www.youtube.com/channel/UCaY2q0UlWjAgEGL7uhCLs6A">YouTube</a> channel.<p>
       </div>
 	  </div>
 </section>
@@ -547,8 +545,6 @@ under the License. -->
 </section> -->
 
 
-
-
 <footer class="bf-footer" role="contentinfo">
     <div class="container">
         <div class="row">
@@ -575,7 +571,7 @@ under the License. -->
                 <ul class="nav nav-list">
                     <li class="nav-header">Resources</li>
                     <li><a href="http://github.com/apache/incubator-geode" target="_blank">GitHub Code</a></li>
-                    <li><a href="http://geode.docs.pivotal.io" target="_blank">Docs</a></li>
+                    <li><a href="/docs/">Docs</a></li>
                     <li><a href="https://issues.apache.org/jira/browse/GEODE" target="_blank">JIRA Bug Tracker</a></li>
                     <li><a href="http://stackoverflow.com/search?q=Apache%20Geode" target="_blank">StackOverflow</a></li>
                     <li><a href="/community/#live">Live Chat</a></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,7 @@
   specific language governing permissions and limitations
   under the License. -->
     <meta charset="utf-8">
-    <title>Apache Geode (incubating) — Performance is key. Consistency is a must.</title>
+    <title>Apache Geode (incubating) — </title>
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1" />
     <meta name="keywords" content="Apache Geode, Geode, GemFire, In-memory, IMDB, IMDG, cache">
@@ -49,7 +49,7 @@
 </head>
 <body>
 
-    <header class="navbar navbar-inverse navbar-fixed-top bf-docs-nav " role="banner">
+    <header class="navbar navbar-inverse navbar-fixed-top bf-docs-nav secondary" role="banner">
     <div class="container">
         <div class="navbar-header">
             <button class="navbar-toggle" type="button" data-toggle="collapse" data-target=".bf-navbar-collapse">
@@ -65,7 +65,7 @@
         <nav class="collapse navbar-collapse bf-navbar-collapse" role="navigation">
             <ul class="nav navbar-nav navbar-right">
                 <li class=""><a href="/community/"><span class="icns icon-group"></span></a></li>
-                <li class=""><a href="/docs/"><span class="icns icon-book"></span></a></li>
+                <li class="active"><a href="/docs/"><span class="icns icon-book"></span></a></li>
                 <li><a href="http://github.com/apache/incubator-geode" target="_blank"><span class="icns icon-github-sign"></span></a></li>
                 <!--<li><a href="https://trello.com/b/exQmJIOn/usergrid" target="_blank"><span class="icns icon-trello"></span></a></li>-->
                 <li><a href="https://issues.apache.org/jira/browse/GEODE/"
@@ -99,128 +99,37 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License. -->
 
-<section class="bf-masthead" id="content" role="main">
-    <div class="bf-masthead-bg">
-        <div class="container">
-            <img class="logo-title img-responsive hidden-xs" src="img/apache_geode_logo.png" />
-            <div class="text-container">
-                <h2 class="tagline"><em>Performance</em> is key. <em>Consistency</em> is a must.</h2>
-                <p class="description">Providing low latency, high concurrency data management solutions since 2002.<br/>
-                  <br/>Build high-speed, data-intensive applications that elastically meet performance requirements at any scale.<br/>
-                  Take advantage of Apache Geode's unique technology that blends advanced techniques for data replication, partitioning and distributed processing.
+<!-- <div id="map-canvas" style="width: 100%;"></div> -->
 
-                  <br/><br/>
-                  Apache Geode (incubating) provides a database-like consistency model, reliable transaction processing and a shared-nothing architecture to maintain very low latency performance with high concurrency processing.<br/>
-            </div>
-
-            <div class="btn-wrapper">
-              <p><a href="/releases/" class="btn btn-inverse btn-lg">Download Geode</a> &nbsp;</p> 
-              <!-- Place this tag where you want the button to render. -->
-              <a class="github-button" href="https://github.com/apache/incubator-geode" data-icon="octicon-star" data-style="mega" data-count-href="/apache/incubator-geode/stargazers" data-count-api="/repos/apache/incubator-geode#stargazers_count" data-count-aria-label="# stargazers on GitHub" aria-label="Star apache/incubator-geode on GitHub">Star</a>
-              <a class="github-button" href="https://github.com/apache/incubator-geode/fork" data-icon="octicon-repo-forked" data-style="mega" data-count-href="/apache/incubator-geode/network" data-count-api="/repos/apache/incubator-geode#forks_count" data-count-aria-label="# forks on GitHub" aria-label="Fork apache/incubator-geode on GitHub">Fork</a>
-              <a class="github-button" href="https://github.com/apache/incubator-geode" data-icon="octicon-eye" data-style="mega" data-count-href="/apache/incubator-geode/watchers" data-count-api="/repos/apache/incubator-geode#subscribers_count" data-count-aria-label="# watchers on GitHub" aria-label="Watch apache/incubator-geode on GitHub">Watch</a>
-
-
-            </div>
-        </div>
+<section class="bf-tagline">
+    <div class="container">
+    	<div class="row">
+        <br/>
+    	    	<h2>Geode Documentation</h2>
+	</div>
     </div>
 </section>
 
-<section class="bf-features">
-    <div class="container">
-        <div class="row">
-            <div class="col-md-4">
-                <div class="bf-icon-wrap"><i style="font-size:65px; vertical-align: -5px;" aria-hidden="true" class="icon-sitemap"></i></div>
-                <h3>Replication and Partitioning</h3>
-                <p>Data can easily be partitioned (sharded) or replicated between nodes allowing performance to scale as needed. Durability is ensured through redundant in-memory copies and disk-based persistence.</p>
-            </div>
-            <div class="col-md-4">
-                <div class="bf-icon-wrap"><i style="font-size:65px; vertical-align: -5px;" aria-hidden="true" class="icon-hdd"></i></div>
-                <h3>Persistence</h3>
-                <p>Super fast write-ahead-logging (WAL) persistence with a shared-nothing architecture that is optimized for fast parallel recovery of nodes or an entire cluster.</p>
-            </div>
-            <div class="col-md-4">
-                <div class="bf-icon-wrap"><i aria-hidden="true" class="icon-rocket"></i></div>
-                <h3>Performance</h3>
-                <p>Linear-scaling low latency for transactions, reads, writes and query processing of indexed or unindexed data.</p>
-            </div>
-        </div>
-        <div class="row">
-            <div class="col-md-4">
-                <div class="bf-icon-wrap" style="font-size:40px; vertical-align: 15px;"><i aria-hidden="true" class="icon-fast-forward"></i><i aria-hidden="true" class="icon-dashboard"></i></div>
-                <h3>In-Memory Storage</h3>
-                <p>Blazing fast in-memory storage optimized for large heaps, with the option of using off-heap storage, compression and features such as disk-overflow, eviction and expiration of data.</p>
-            </div>
-            <div class="col-md-4">
-                <div class="bf-icon-wrap"><span style="font-size:60px" aria-hidden="true" class="icon-cogs"></span></div>
-                <h3>Functions</h3>
-                <p>Distributed location-aware user functions can be deployed and executed by the same nodes storing relevant sharded data for fast parallel processing. Failed operations can be retried on replicant nodes.</p>
-            </div>
-            <div class="col-md-4">
-                <div class="bf-icon-wrap"><i style="font-size:65px; vertical-align: -5px;" aria-hidden="true" class="icon-credit-card"></i></div>
-                <h3>Transactions</h3>
-                <p>ACID distributed transactions support efficient and safe coordinated operations on colocated data. Transactions can be initiated or suspended by either a client or a server.</p>
-            </div>
-        </div>
-        <div class="row">
-          <div class="col-md-4">
-              <div class="bf-icon-wrap"><i style="font-size:65px; vertical-align: -5px;" aria-hidden="true" class="icon-table"></i></div>
-              <h3>OQL and Indexes</h3>
-              <p>Object Query Language allows distributed query execution on hot and cold data, with SQL-like capabilities, including joins.<br/>
-              Multiple kinds of indexes can be defined and consistently maintained across the cluster.</p>
-          </div>
-          <div class="col-md-4">
-              <div class="bf-icon-wrap"><i style="font-size:65px; vertical-align: -5px;" aria-hidden="true" class="icon-bolt"></i></div>
-              <h3>Events</h3>
-              <p>Clients can be notified about server-side data events, and servers can react synchronously or asynchronously with guaranteed delivery of ordered events.</p>
-          </div>
-          <div class="col-md-4">
-              <div class="bf-icon-wrap"><i style="font-size:65px; vertical-align: -5px;" aria-hidden="true" class="icon-cloud"></i></div>
-              <h3>Clustering</h3>
-              <p>Highly scalable, robust advanced clustering technology with failure detection, dynamic scaling, and network-partition detection algorithms.</p>
-          </div>
-        </div>
-    </div>
 
+<section class="bf-docs">
+    <div class="container">
+	<div class="row">
+	    <div class="col-md-4">
+	    		<h3><a href="http://geode.docs.pivotal.io/" style="color: #1275ff;">Apache Geode (incubating) User Documentation</a></h3>
+	    		<p>Installation Instructions, User Manual, other product docs</p>
+	    </div>
+	    <div class="col-md-4">
+	    		<h3><a href="http://geode.incubator.apache.org/releases/10M2SNAP/javadocs/index.html" style="color: #1275ff;">Javadocs</a></h3>
+	    		<p>API Reference in conventional Javadoc format<p>
+	    </div>
+	    <div class="col-md-4">
+	    		<h3><a href="https://cwiki.apache.org/confluence/display/GEODE/Index" style="color: #1275ff;">Apache Geode Wiki</a></h3>
+	    		<p>Community contributions on various topics<p>
+	    </div>
+	</div>
     </div>
 </section>
 
-<section class="bf-questions">
-    <div class="container">
-            <div class="col-md-12 text-center cta">
-                And much more... Interested? You can check our <a href="https://cwiki.apache.org/confluence/display/GEODE/Index#Index-Geodein5minutesGeodein5minutes" target="_blank" class="btn btn-inverse btn-lg">Geode in 5 minutes tutorial</a> <span class="avoidwrap">, ask a question on the <a href="/community/" class="btn btn-inverse btn-lg">Mailing lists</a> or <a href="http://stackoverflow.com/search?q=Apache%20Geode" class="btn btn-inverse btn-lg">StackOverflow</a></span>
-            </div>
-    </div>
-</section
-
-<section class="bf-news">
-    <div class="container">
-
-        <div class="row">
-            <div class="col-md-12 text-left">
-                <h2>About the Project</h2>
-                <p>Apache Geode (incubating) is a data management platform that provides real-time, consistent access to data-intensive applications throughout widely distributed cloud architectures.</p>
-
-                <p>By pooling memory, CPU, network resources, and (optionally) local disk across multiple processes to manage application objects and behavior, it uses dynamic replication and data partitioning techniques to implement high availability, improved performance, scalability, and fault tolerance. In addition to being a distributed data container, Apache Geode is an in-memory data management system that provides reliable asynchronous event notifications and guaranteed message delivery.</p>
-
-                <p>Apache Geode is a mature, robust technology originally developed by GemStone Systems in Beaverton, Oregon.
-Commercially available as GemFire™, the technology was first widely deployed in the financial sector as the transactional, low-latency data engine used
-in Wall Street trading platforms.
-Today Apache Geode is used by over 600 enterprise customers for high-scale business applications that must meet low latency and 24x7 availability requirements.</p>
-
-                <p>This project is undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Incubator. Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects. While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.</p>
-            </div>
-            <!--
-            <div class="col-md-4 text-left">
-                <h2>Recent Releases</h2>
-
-
-            </div>
-            -->
-        </div>
-
-    </div>
-</section>
 
 
 <footer class="bf-footer" role="contentinfo">

--- a/releases/index.html
+++ b/releases/index.html
@@ -65,7 +65,7 @@
         <nav class="collapse navbar-collapse bf-navbar-collapse" role="navigation">
             <ul class="nav navbar-nav navbar-right">
                 <li class=""><a href="/community/"><span class="icns icon-group"></span></a></li>
-                <li><a href="http://geode.docs.pivotal.io" target="_blank"><span class="icns icon-book"></span></a></li>
+                <li class=""><a href="/docs/"><span class="icns icon-book"></span></a></li>
                 <li><a href="http://github.com/apache/incubator-geode" target="_blank"><span class="icns icon-github-sign"></span></a></li>
                 <!--<li><a href="https://trello.com/b/exQmJIOn/usergrid" target="_blank"><span class="icns icon-trello"></span></a></li>-->
                 <li><a href="https://issues.apache.org/jira/browse/GEODE/"
@@ -80,8 +80,6 @@
         </nav>
     </div>
     </header>
-
-
 
 
 <!-- Licensed to the Apache Software Foundation (ASF) under one
@@ -215,8 +213,6 @@ under the License. -->
 </section>
 
 
-
-
 <footer class="bf-footer" role="contentinfo">
     <div class="container">
         <div class="row">
@@ -243,7 +239,7 @@ under the License. -->
                 <ul class="nav nav-list">
                     <li class="nav-header">Resources</li>
                     <li><a href="http://github.com/apache/incubator-geode" target="_blank">GitHub Code</a></li>
-                    <li><a href="http://geode.docs.pivotal.io" target="_blank">Docs</a></li>
+                    <li><a href="/docs/">Docs</a></li>
                     <li><a href="https://issues.apache.org/jira/browse/GEODE" target="_blank">JIRA Bug Tracker</a></li>
                     <li><a href="http://stackoverflow.com/search?q=Apache%20Geode" target="_blank">StackOverflow</a></li>
                     <li><a href="/community/#live">Live Chat</a></li>


### PR DESCRIPTION
Add a docs landing page which includes a link to apache-hosted javadocs