### PR TITLE
GEODE-247: Fix in executeQuery function to use the bucket parameter

### DIFF
--- a/geode-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalDataSet.java
+++ b/geode-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalDataSet.java
@@ -186,7 +186,7 @@ public final class LocalDataSet implements Region, QueryExecutor {
     QueryObserver indexObserver = query.startTrace();
 
     try{
-      result = this.proxy.executeQuery(query, parameters, getBucketSet());
+      result = this.proxy.executeQuery(query, parameters, buckets);
     }
     finally {
       query.endTrace(indexObserver, startTime, result);

--- a/geode-core/src/test/java/com/gemstone/gemfire/cache/query/QueryWithBucketParameterIntegrationTest.java
+++ b/geode-core/src/test/java/com/gemstone/gemfire/cache/query/QueryWithBucketParameterIntegrationTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * QueryWithBucketParameterIntegrationTest.java
+ * JUnit based test
+ */
+package com.gemstone.gemfire.cache.query;
+
+import static com.gemstone.gemfire.cache.query.data.TestData.*;
+import static org.junit.Assert.*;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.gemstone.gemfire.cache.Cache;
+import com.gemstone.gemfire.cache.EntryOperation;
+import com.gemstone.gemfire.cache.PartitionAttributesFactory;
+import com.gemstone.gemfire.cache.PartitionResolver;
+import com.gemstone.gemfire.cache.RegionFactory;
+import com.gemstone.gemfire.cache.RegionShortcut;
+import com.gemstone.gemfire.cache.query.internal.DefaultQuery;
+import com.gemstone.gemfire.internal.cache.LocalDataSet;
+import com.gemstone.gemfire.internal.cache.PartitionedRegion;
+import com.gemstone.gemfire.test.junit.categories.IntegrationTest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * @implNote This test class has been designed to test the query execution using the LocalDataSet.executeQuery
+ * where one of the parameters passed is the bucket set to be used.
+ * Different variation of hashset variables are passed to the function to check for errors.
+ */
+@Category(IntegrationTest.class)
+public class QueryWithBucketParameterIntegrationTest {
+  DefaultQuery queryExecutor;
+  LocalDataSet lds;
+
+  public QueryWithBucketParameterIntegrationTest() {}
+
+  @Before
+  public void setUp() throws Exception {
+    String regionName = "pr1";
+    int totalBuckets = 40;
+    int numValues = 80;
+    CacheUtils.startCache();
+    Cache cache = CacheUtils.getCache();
+    PartitionAttributesFactory pAFactory = getPartitionAttributesFactoryWithPartitionResolver(totalBuckets);
+    RegionFactory rf = cache.createRegionFactory(RegionShortcut.PARTITION);
+    rf.setPartitionAttributes(pAFactory.create());
+    PartitionedRegion pr1 = (PartitionedRegion) rf.create(regionName);
+    populateRegion(pr1, numValues);
+    QueryService qs = pr1.getCache().getQueryService();
+    String query = "select distinct e1.value from /pr1 e1";
+    queryExecutor = (DefaultQuery)CacheUtils.getQueryService().newQuery(
+      query);
+    Set<Integer> set = createAndPopulateSet(totalBuckets);
+    lds = new LocalDataSet(pr1, set);
+  }
+
+  private PartitionAttributesFactory getPartitionAttributesFactoryWithPartitionResolver(int totalBuckets) {
+    PartitionAttributesFactory pAFactory = new PartitionAttributesFactory();
+    pAFactory.setRedundantCopies(1).setTotalNumBuckets(totalBuckets).setPartitionResolver(
+      getPartitionResolver());
+    return pAFactory;
+  }
+
+  private PartitionResolver getPartitionResolver() {
+    return new PartitionResolver() {
+      public String getName()
+      {
+        return "PartitionResolverForTest";
+      }
+      public Serializable getRoutingObject(EntryOperation opDetails)
+      {
+        return (Serializable)opDetails.getKey();
+      }
+      public void close() {}
+    };
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    CacheUtils.closeCache();
+  }
+
+  @Test
+  public void testQueryExecuteWithEmptyBucketListExpectNoResults() throws Exception
+  {
+    SelectResults r = (SelectResults)lds.executeQuery(queryExecutor, null, new HashSet<Integer>());
+    assertTrue("Received: A non-empty result collection, expected : Empty result collection", r.isEmpty());
+  }
+
+  @Test
+  public void testQueryExecuteWithNullBucketListExpectNonEmptyResultSet() throws Exception
+  {
+    SelectResults r = (SelectResults)lds.executeQuery(queryExecutor, null, null);
+    assertFalse("Received: An empty result collection, expected : Non-empty result collection", r.isEmpty());
+  }
+
+  @Test
+  public void testQueryExecuteWithNonEmptyBucketListExpectNonEmptyResultSet() throws Exception
+  {
+    int nTestBucketNumber = 15;
+    Set<Integer> nonEmptySet = createAndPopulateSet(nTestBucketNumber);
+    SelectResults r = (SelectResults)lds.executeQuery(queryExecutor, null, nonEmptySet);
+    assertFalse("Received: An empty result collection, expected : Non-empty result collection", r.isEmpty());
+  }
+
+  @Test(expected = QueryInvocationTargetException.class)
+  public void testQueryExecuteWithLargerBucketListThanExistingExpectQueryInvocationTargetException() throws Exception
+  {
+    int nTestBucketNumber = 45;
+    Set<Integer> overflowSet = createAndPopulateSet(nTestBucketNumber);
+    SelectResults r = (SelectResults)lds.executeQuery(queryExecutor, null, overflowSet);
+  }
+}

--- a/geode-core/src/test/java/com/gemstone/gemfire/cache/query/data/TestData.java
+++ b/geode-core/src/test/java/com/gemstone/gemfire/cache/query/data/TestData.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * TestData.java
+ * Contains data elements to be used in JUnit based tests
+ * Created on April 13, 2005, 2:40 PM
+ */
+package com.gemstone.gemfire.cache.query.data;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import com.gemstone.gemfire.cache.Region;
+
+public class TestData {
+  public static void populateRegion(Region region, int numValues) {
+    IntStream.rangeClosed(1,numValues).forEach(i -> region.put(i,new MyValue(i)));
+  }
+
+  public static Set<Integer> createAndPopulateSet(int nBuckets) {
+    return new HashSet<Integer>(IntStream.range(0,nBuckets).boxed().collect(Collectors.toSet()));
+  }
+
+  public static class MyValue implements Serializable, Comparable<MyValue>
+  {
+    public int value = 0;
+    public MyValue(int value) {
+      this.value = value;
+    }
+    public int compareTo(MyValue o)
+    {
+      if(this.value > o.value) {
+        return 1;
+      }else if(this.value < o.value) {
+        return -1;
+      }else {
+        return 0;
+      }
+    }
+  }
+}


### PR DESCRIPTION
GEODE-247: Fix in executeQuery function to use the bucket parameter and added tests cases for it.

* modification of the function executeQuery to use the parameter bucket rather than ignoring it.
* added integration test QueryWithBucketParameterIntegrationTest which tests variations in the  bucket parameter.
* code improvements done as per the review comments in github pull request
* placed MyValue, createAndPopulateSet and populateRegion into a separate file TestData.java as being reused by two test cases to avoid redundant code
* modified BugJUnitTest to import the TestData package and replaced for loops with IntStreams and lambda functions.

NOTE: This is an internal API which needs to be deprecated and replaced with an API without the bucket parameter.