### PR TITLE
GEODE-1061: Made the update operations to be synchronous and made sure executeCQ happens before updates

### DIFF
--- a/geode-cq/src/main/java/com/gemstone/gemfire/cache/query/internal/cq/ServerCQImpl.java
+++ b/geode-cq/src/main/java/com/gemstone/gemfire/cache/query/internal/cq/ServerCQImpl.java
@@ -69,7 +69,12 @@ public class ServerCQImpl extends CqQueryImpl implements DataSerializable, Serve
    * This holds the keys that are part of the CQ query results.
    * Using this CQ engine can determine whether to execute 
    * query on old value from EntryEvent, which is an expensive
-   * operation. 
+   * operation.
+   *
+   * NOTE:
+   * In case of RR this map is populated and used as intended.
+   * In case of PR this map will not be populated. If executeCQ happens after update operations
+   * this map will remain empty.
    */
   private volatile HashMap<Object, Object> cqResultKeys;
 

--- a/geode-cq/src/test/java/com/gemstone/gemfire/cache/query/cq/dunit/CqResultSetUsingPoolDUnitTest.java
+++ b/geode-cq/src/test/java/com/gemstone/gemfire/cache/query/cq/dunit/CqResultSetUsingPoolDUnitTest.java
@@ -764,9 +764,11 @@ public class CqResultSetUsingPoolDUnitTest extends CacheTestCase {
         }
       }
     });
-    
+
+    cqDUnitTest.executeCQ(client, cqName, true, null);
+
     // Keep updating region (async invocation).
-    server2.invokeAsync(new CacheSerializableRunnable("Update Region"){
+    server2.invoke(new CacheSerializableRunnable("Update Region"){
       public void run2()throws CacheException {
         Region region = getCache().getRegion("/root/" + cqDUnitTest.regions[0]);
         // Update (totalObjects - 1) entries.
@@ -790,10 +792,6 @@ public class CqResultSetUsingPoolDUnitTest extends CacheTestCase {
       }
     });
 
-    // Execute CQ.
-    // While region operation is in progress execute CQ.
-    cqDUnitTest.executeCQ(client, cqName, true, null);
-    
     // Verify CQ Cache results.
     server1.invoke(new CacheSerializableRunnable("Verify CQ Cache results"){
       public void run2()throws CacheException {
@@ -803,20 +801,6 @@ public class CqResultSetUsingPoolDUnitTest extends CacheTestCase {
         } catch (Exception ex) {
           LogWriterUtils.getLogWriter().info("Failed to get the internal CqService.", ex);
           Assert.fail ("Failed to get the internal CqService.", ex);
-        }
-        
-        // Wait till all the region update is performed.
-        Region region = getCache().getRegion("/root/" + cqDUnitTest.regions[0]);
-        while(true){
-          if (region.get(""+ totalObjects) == null){
-            try {
-              Thread.sleep(50);
-            } catch (Exception ex){
-              //ignore.
-            }
-            continue;
-          }
-          break;
         }
         Collection<? extends InternalCqQuery> cqs = cqService.getAllCqs();
         for (InternalCqQuery cq: cqs){


### PR DESCRIPTION
GEODE-1061: Made the update operations to be synchronous and made sure executeCQ happens before updates

* Moved function execution of executeCQ before region updates because if all the updates finish before executeCQ, the test will fail because the cache map size will be zero. This is a feature for PR regions.
* Made all update operations to be synchronous rather than using sleep and infinite while loop to wait.