### PR TITLE
GEODE-1018: Added a listener to make the receiver go to sleep on AfterCreate event to solve timing issue.

### DIFF
--- a/geode-wan/src/test/java/com/gemstone/gemfire/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/test/java/com/gemstone/gemfire/internal/cache/wan/WANTestBase.java
@@ -1364,8 +1364,7 @@ public class WANTestBase extends DistributedTestCase{
             Thread.sleep(milliSeconds);
           }
           catch (InterruptedException e) {
-            e.printStackTrace();
-            throw new RuntimeException(e);
+            Thread.currentThread().interrupt();
           }
         }
       });

--- a/geode-wan/src/test/java/com/gemstone/gemfire/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/test/java/com/gemstone/gemfire/internal/cache/wan/WANTestBase.java
@@ -1355,6 +1355,23 @@ public class WANTestBase extends DistributedTestCase{
     }
   }
 
+  public static void addListenerToSleepAfterCreateEvent(int milliSeconds) {
+    cache.getRegion(getTestMethodName() + "_RR_1").getAttributesMutator()
+      .addCacheListener(new CacheListenerAdapter<Object, Object>() {
+        @Override
+        public void afterCreate(final EntryEvent<Object, Object> event) {
+          try {
+            Thread.sleep(milliSeconds);
+          }
+          catch (InterruptedException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+          }
+        }
+      });
+  }
+
+
   public static void createCache(Integer locPort){
     createCache(false, locPort);
   }

--- a/geode-wan/src/test/java/com/gemstone/gemfire/internal/cache/wan/serial/SerialWANPropogationDUnitTest.java
+++ b/geode-wan/src/test/java/com/gemstone/gemfire/internal/cache/wan/serial/SerialWANPropogationDUnitTest.java
@@ -782,54 +782,42 @@ public class SerialWANPropogationDUnitTest extends WANTestBase {
     // senders are created on local site. Batch size is kept to a high (170) so
     // there will be less number of exceptions (occur during dispatchBatch) in
     // the log
-    vm4.invoke(() -> WANTestBase.createSender( "ln", 2,
-        false, 100, 350, false, true, null, true ));
-    vm5.invoke(() -> WANTestBase.createSender( "ln", 2,
-        false, 100, 350, false, true, null, true ));
+    vm4.invoke(() -> WANTestBase.createSender( "ln", 2, false, 100, 350, false, true, null, true ));
+    vm5.invoke(() -> WANTestBase.createSender("ln", 2, false, 100, 350, false, true, null, true));
 
     // create one RR (RR_1) on remote site
-    vm2.invoke(() -> WANTestBase.createPersistentReplicatedRegion( getTestMethodName() + "_RR_1", null, isOffHeap()  ));
-
+    vm2.invoke(() -> WANTestBase.createPersistentReplicatedRegion(getTestMethodName() + "_RR_1", null, isOffHeap()));
+    vm2.invoke(() -> WANTestBase.addListenerToSleepAfterCreateEvent(2000));
     // start the senders on local site
     startSenderInVMs("ln", vm4, vm5);
 
     // create one RR (RR_1) on local site
-    vm4.invoke(() -> WANTestBase.createReplicatedRegion(
-        getTestMethodName() + "_RR_1", "ln", isOffHeap()  ));
+    vm4.invoke(() -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR_1", "ln", isOffHeap()));
 
     
     // start puts in RR_1 in another thread
     AsyncInvocation inv1 = vm4.invokeAsync(() -> WANTestBase.doPuts( getTestMethodName() + "_RR_1", 8000 ));
     // close cache in remote site. This will automatically kill the remote
     // receivers.
-    Wait.pause(2000);
     vm2.invoke(() -> WANTestBase.closeCache());
-    // vm3.invoke(() -> WANTestBase.closeCache());
 
-    try {
-      inv1.join();
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-      fail();
-    }
+
+    inv1.join();
 
     // verify that all is well in local site
-    vm4.invoke(() -> WANTestBase.validateRegionSize(
-        getTestMethodName() + "_RR_1", 8000 ));
+    vm4.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_RR_1", 8000));
 
     vm4.invoke(() -> WANTestBase.verifyRegionQueueNotEmpty( "ln" ));
 
     createCacheInVMs(nyPort, vm2);
-    vm2.invoke(() -> WANTestBase.createPersistentReplicatedRegion( getTestMethodName() + "_RR_1", null, isOffHeap()  ));
+    vm2.invoke(() -> WANTestBase.createPersistentReplicatedRegion(getTestMethodName() + "_RR_1", null, isOffHeap()));
     vm2.invoke(() -> WANTestBase.createReceiver( nyPort ));
 
-    vm4.invoke(() -> WANTestBase.validateQueueContents( "ln",
-        0 ));
+    vm4.invoke(() -> WANTestBase.validateQueueContents("ln", 0));
 
-    vm2.invoke(() -> WANTestBase.checkMinimumGatewayReceiverStats( 1, 1 ));
+    vm2.invoke(() -> WANTestBase.checkMinimumGatewayReceiverStats(1, 1));
 
-    vm2.invoke(() -> WANTestBase.validateRegionSize(
-        getTestMethodName() + "_RR_1", 8000 ));
+    vm2.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_RR_1", 8000));
   }
 
   public void testReplicatedSerialPropagationWithRemoteSiteBouncedBack_ReceiverPersistent()


### PR DESCRIPTION
GEODE-1018: Added a listener to make the receiver go to sleep on AfterCreate event to solve timing issue.

* Added a listener in the receiver VM to sleep for a duration on AfterCreate event. This will make sure that the transmission is not completed by the time the receiver is shut down.
* The region entry mismatch mentioned in the GEODE-1018 was because the receiver and sender were started before the persistent region was created. This was solved in GEODE-1062.