### PR TITLE
GEODE-935: Removed the sleeps to speed up tests.

### DIFF
--- a/geode-wan/src/test/java/com/gemstone/gemfire/internal/cache/wan/serial/SerialWANPropogationDUnitTest.java
+++ b/geode-wan/src/test/java/com/gemstone/gemfire/internal/cache/wan/serial/SerialWANPropogationDUnitTest.java
@@ -137,8 +137,6 @@ public class SerialWANPropogationDUnitTest extends WANTestBase {
     vm2.invoke(() -> WANTestBase.createReceiver());
     vm3.invoke(() -> WANTestBase.createReceiver());
 
-    Thread.sleep(5000);
-
     vm4.invoke(() -> WANTestBase.validateRegionSize(
         getTestMethodName() + "_RR", 1000 ));
 
@@ -384,8 +382,6 @@ public class SerialWANPropogationDUnitTest extends WANTestBase {
       e.printStackTrace();
       fail();
     }
-    //sleep for some time to let all the events propagate to remote site
-    Thread.sleep(20);
     //vm4.invoke(() -> WANTestBase.verifyQueueSize( "ln", 0 ));
     vm2.invoke(() -> WANTestBase.validateRegionSize(
         getTestMethodName() + "_RR_1", 1000 ));


### PR DESCRIPTION
* The sleeps in the test cases were removed as the awaitility clause in the subsequent validate region size waits for at max 30 sec.