### PR TITLE
GEODE-710: Replaced thread.sleep with Awaitility

### DIFF
--- a/geode-core/src/test/java/com/gemstone/gemfire/internal/ScheduledThreadPoolExecutorWithKeepAliveJUnitTest.java
+++ b/geode-core/src/test/java/com/gemstone/gemfire/internal/ScheduledThreadPoolExecutorWithKeepAliveJUnitTest.java
@@ -35,6 +35,7 @@ import org.junit.experimental.categories.Category;
 
 import com.gemstone.gemfire.test.junit.categories.FlakyTest;
 import com.gemstone.gemfire.test.junit.categories.IntegrationTest;
+import com.jayway.awaitility.Awaitility;
 
 @Category(IntegrationTest.class)
 public class ScheduledThreadPoolExecutorWithKeepAliveJUnitTest {
@@ -190,9 +191,12 @@ public class ScheduledThreadPoolExecutorWithKeepAliveJUnitTest {
       }
     };
     ScheduledFuture f = ex.scheduleAtFixedRate(run, 0, 1, TimeUnit.SECONDS);
-    Thread.sleep(5000);
-    f.cancel(true);
-    assertTrue("Task was not executed repeatedly", counter.get() > 1);
+    Awaitility.await().atMost(30,TimeUnit.SECONDS).until(() -> assertEquals("Task was not executed repeatedly"
+      ,true, counter.get() > 1));
+    Awaitility.await().atMost(30, TimeUnit.SECONDS).until(() -> assertEquals("The task could not be cancelled"
+      ,true, f.cancel(true)));
+    Awaitility.await().atMost(30,TimeUnit.SECONDS).until(() -> assertEquals("Task was not cancelled within 30 sec"
+      ,true,f.isCancelled()));
     int oldValue = counter.get();
     Thread.sleep(5000);
     assertEquals("Task was not cancelled", oldValue, counter.get());


### PR DESCRIPTION
* Replaced thread.sleep with awaitility.
* Place an awaitility to wait for the isCancelled flag to be true before checking the counter values.