### PR TITLE
GEODE-1262: Removed VM5-VM7 in AsyncEventQueueTestBase

### DIFF
--- a/geode-core/src/test/java/com/gemstone/gemfire/internal/cache/wan/AsyncEventQueueTestBase.java
+++ b/geode-core/src/test/java/com/gemstone/gemfire/internal/cache/wan/AsyncEventQueueTestBase.java
@@ -101,12 +101,6 @@ public class AsyncEventQueueTestBase extends DistributedTestCase {
 
   protected static VM vm4;
 
-  protected static VM vm5;
-
-  protected static VM vm6;
-
-  protected static VM vm7;
-
   protected static AsyncEventListener eventListener1;
 
   private static final long MAX_WAIT = 10000;
@@ -134,9 +128,6 @@ public class AsyncEventQueueTestBase extends DistributedTestCase {
     vm2 = host.getVM(2);
     vm3 = host.getVM(3);
     vm4 = host.getVM(4);
-    vm5 = host.getVM(5);
-    vm6 = host.getVM(6);
-    vm7 = host.getVM(7);
   }
 
   @Override
@@ -1549,9 +1540,6 @@ public class AsyncEventQueueTestBase extends DistributedTestCase {
     vm2.invoke(() -> AsyncEventQueueTestBase.cleanupVM());
     vm3.invoke(() -> AsyncEventQueueTestBase.cleanupVM());
     vm4.invoke(() -> AsyncEventQueueTestBase.cleanupVM());
-    vm5.invoke(() -> AsyncEventQueueTestBase.cleanupVM());
-    vm6.invoke(() -> AsyncEventQueueTestBase.cleanupVM());
-    vm7.invoke(() -> AsyncEventQueueTestBase.cleanupVM());
   }
 
   public static void cleanupVM() throws IOException {

--- a/geode-core/src/test/java/com/gemstone/gemfire/internal/cache/wan/asyncqueue/AsyncEventListenerDUnitTest.java
+++ b/geode-core/src/test/java/com/gemstone/gemfire/internal/cache/wan/asyncqueue/AsyncEventListenerDUnitTest.java
@@ -76,49 +76,49 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
   public void testSerialAsyncEventQueueAttributes() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
-    vm4.invoke(createCacheRunnable(lnPort));
+    vm1.invoke(createCacheRunnable(lnPort));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
         false, 100, 150, true, true, "testDS", true ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventQueueAttributes( "ln", 100, 150, AsyncEventQueueFactoryImpl.DEFAULT_BATCH_TIME_INTERVAL, true, "testDS", true, true ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventQueueAttributes( "ln", 100, 150, AsyncEventQueueFactoryImpl.DEFAULT_BATCH_TIME_INTERVAL, true, "testDS", true, true ));
   }
   
   public void testSerialAsyncEventQueueSize() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
+    vm3.invoke(createCacheRunnable(lnPort));
     vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
-    vm6.invoke(createCacheRunnable(lnPort));
-    vm7.invoke(createCacheRunnable(lnPort));
 
+    vm1.invoke(createAsyncEventQueueRunnable());
+    vm2.invoke(createAsyncEventQueueRunnable());
+    vm3.invoke(createAsyncEventQueueRunnable());
     vm4.invoke(createAsyncEventQueueRunnable());
-    vm5.invoke(createAsyncEventQueueRunnable());
-    vm6.invoke(createAsyncEventQueueRunnable());
-    vm7.invoke(createAsyncEventQueueRunnable());
 
+    vm1.invoke(createReplicatedRegionRunnable());
+    vm2.invoke(createReplicatedRegionRunnable());
+    vm3.invoke(createReplicatedRegionRunnable());
     vm4.invoke(createReplicatedRegionRunnable());
-    vm5.invoke(createReplicatedRegionRunnable());
-    vm6.invoke(createReplicatedRegionRunnable());
-    vm7.invoke(createReplicatedRegionRunnable());
 
+    vm1
+        .invoke(pauseAsyncEventQueueRunnable());
+    vm2
+        .invoke(pauseAsyncEventQueueRunnable());
+    vm3
+        .invoke(pauseAsyncEventQueueRunnable());
     vm4
-        .invoke(pauseAsyncEventQueueRunnable());
-    vm5
-        .invoke(pauseAsyncEventQueueRunnable());
-    vm6
-        .invoke(pauseAsyncEventQueueRunnable());
-    vm7
         .invoke(pauseAsyncEventQueueRunnable());
     Wait.pause(1000);// pause at least for the batchTimeInterval
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
         1000 ));
 
-    int vm4size = (Integer)vm4.invoke(() -> AsyncEventQueueTestBase.getAsyncEventQueueSize( "ln" ));
-    int vm5size = (Integer)vm5.invoke(() -> AsyncEventQueueTestBase.getAsyncEventQueueSize( "ln" ));
-    assertEquals("Size of AsyncEventQueue is incorrect", 1000, vm4size);
-    assertEquals("Size of AsyncEventQueue is incorrect", 1000, vm5size);
+    int vm1size = (Integer)vm1.invoke(() -> AsyncEventQueueTestBase.getAsyncEventQueueSize( "ln" ));
+    int vm2size = (Integer)vm2.invoke(() -> AsyncEventQueueTestBase.getAsyncEventQueueSize( "ln" ));
+    assertEquals("Size of AsyncEventQueue is incorrect", 1000, vm1size);
+    assertEquals("Size of AsyncEventQueue is incorrect", 1000, vm2size);
   }
 
   protected SerializableRunnableIF pauseAsyncEventQueueRunnable() {
@@ -145,35 +145,35 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
   public void testConcurrentSerialAsyncEventQueueSize() {
 	Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+	vm1.invoke(createCacheRunnable(lnPort));
+	vm2.invoke(createCacheRunnable(lnPort));
+	vm3.invoke(createCacheRunnable(lnPort));
 	vm4.invoke(createCacheRunnable(lnPort));
-	vm5.invoke(createCacheRunnable(lnPort));
-	vm6.invoke(createCacheRunnable(lnPort));
-	vm7.invoke(createCacheRunnable(lnPort));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+    vm1.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
         false, 100, 150, true, false, null, false, 2, OrderPolicy.KEY ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+    vm2.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
         false, 100, 150, true, false, null, false, 2, OrderPolicy.KEY ));
 
+	vm1.invoke(createReplicatedRegionRunnable());
+	vm2.invoke(createReplicatedRegionRunnable());
+	vm3.invoke(createReplicatedRegionRunnable());
 	vm4.invoke(createReplicatedRegionRunnable());
-	vm5.invoke(createReplicatedRegionRunnable());
-	vm6.invoke(createReplicatedRegionRunnable());
-	vm7.invoke(createReplicatedRegionRunnable());
 
-	vm4
+	vm1
 	  .invoke(pauseAsyncEventQueueRunnable());
-	vm5
+	vm2
 	  .invoke(pauseAsyncEventQueueRunnable());
 
 	Wait.pause(1000);// pause at least for the batchTimeInterval
 
-	vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
+	vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
 		1000 ));
 
-	int vm4size = (Integer)vm4.invoke(() -> AsyncEventQueueTestBase.getAsyncEventQueueSize( "ln" ));
-	int vm5size = (Integer)vm5.invoke(() -> AsyncEventQueueTestBase.getAsyncEventQueueSize( "ln" ));
-	assertEquals("Size of AsyncEventQueue is incorrect", 1000, vm4size);
-	assertEquals("Size of AsyncEventQueue is incorrect", 1000, vm5size);
+	int vm1size = (Integer)vm1.invoke(() -> AsyncEventQueueTestBase.getAsyncEventQueueSize( "ln" ));
+	int vm2size = (Integer)vm2.invoke(() -> AsyncEventQueueTestBase.getAsyncEventQueueSize( "ln" ));
+	assertEquals("Size of AsyncEventQueue is incorrect", 1000, vm1size);
+	assertEquals("Size of AsyncEventQueue is incorrect", 1000, vm2size);
   }
   
   /**
@@ -186,28 +186,28 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
   public void testReplicatedSerialAsyncEventQueue() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
+    vm3.invoke(createCacheRunnable(lnPort));
     vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
-    vm6.invoke(createCacheRunnable(lnPort));
-    vm7.invoke(createCacheRunnable(lnPort));
 
+    vm1.invoke(createAsyncEventQueueRunnable());
+    vm2.invoke(createAsyncEventQueueRunnable());
+    vm3.invoke(createAsyncEventQueueRunnable());
     vm4.invoke(createAsyncEventQueueRunnable());
-    vm5.invoke(createAsyncEventQueueRunnable());
-    vm6.invoke(createAsyncEventQueueRunnable());
-    vm7.invoke(createAsyncEventQueueRunnable());
 
+    vm1.invoke(createReplicatedRegionRunnable());
+    vm2.invoke(createReplicatedRegionRunnable());
+    vm3.invoke(createReplicatedRegionRunnable());
     vm4.invoke(createReplicatedRegionRunnable());
-    vm5.invoke(createReplicatedRegionRunnable());
-    vm6.invoke(createReplicatedRegionRunnable());
-    vm7.invoke(createReplicatedRegionRunnable());
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
         1000 ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 1000 ));// primary sender
-    vm5.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
-    vm6.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
-    vm7.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 1000 ));// primary sender
+    vm2.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm3.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
   }
   
   /**
@@ -217,32 +217,32 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
   public void testReplicatedSerialAsyncEventQueueWithCacheLoader() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
+    vm3.invoke(createCacheRunnable(lnPort));
     vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
-    vm6.invoke(createCacheRunnable(lnPort));
-    vm7.invoke(createCacheRunnable(lnPort));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        false, 100, 100, false, false, null, false, "MyAsyncEventListener_CacheLoader" ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        false, 100, 100, false, false, null, false, "MyAsyncEventListener_CacheLoader" ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        false, 100, 100, false, false, null, false, "MyAsyncEventListener_CacheLoader" ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
         false, 100, 100, false, false, null, false, "MyAsyncEventListener_CacheLoader" ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        false, 100, 100, false, false, null, false, "MyAsyncEventListener_CacheLoader" ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        false, 100, 100, false, false, null, false, "MyAsyncEventListener_CacheLoader" ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        false, 100, 100, false, false, null, false, "MyAsyncEventListener_CacheLoader" ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithCacheLoaderAndAsyncEventQueue( getTestMethodName() + "_RR", "ln" ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithCacheLoaderAndAsyncEventQueue( getTestMethodName() + "_RR", "ln" ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithCacheLoaderAndAsyncEventQueue( getTestMethodName() + "_RR", "ln" ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithCacheLoaderAndAsyncEventQueue( getTestMethodName() + "_RR", "ln" ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithCacheLoaderAndAsyncEventQueue( getTestMethodName() + "_RR", "ln" ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithCacheLoaderAndAsyncEventQueue( getTestMethodName() + "_RR", "ln" ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithCacheLoaderAndAsyncEventQueue( getTestMethodName() + "_RR", "ln" ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.doGets( getTestMethodName() + "_RR",
+    vm1.invoke(() -> AsyncEventQueueTestBase.doGets( getTestMethodName() + "_RR",
         10 ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventForOperationDetail( "ln", 10, true, false ));// primary sender
-    vm5.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventForOperationDetail( "ln", 0, true, false ));// secondary
-    vm6.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventForOperationDetail( "ln", 0, true, false ));// secondary
-    vm7.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventForOperationDetail( "ln", 0, true, false ));// secondary
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventForOperationDetail( "ln", 10, true, false ));// primary sender
+    vm2.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventForOperationDetail( "ln", 0, true, false ));// secondary
+    vm3.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventForOperationDetail( "ln", 0, true, false ));// secondary
+    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventForOperationDetail( "ln", 0, true, false ));// secondary
   }
   
   /**
@@ -260,47 +260,47 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
   public void testReplicatedSerialAsyncEventQueue_ExceptionScenario() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
+    vm3.invoke(createCacheRunnable(lnPort));
     vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
-    vm6.invoke(createCacheRunnable(lnPort));
-    vm7.invoke(createCacheRunnable(lnPort));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithCustomListener( "ln",
+        false, 100, 100, false, false, null, false, 1 ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithCustomListener( "ln",
+        false, 100, 100, false, false, null, false, 1 ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithCustomListener( "ln",
+        false, 100, 100, false, false, null, false, 1 ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithCustomListener( "ln",
         false, 100, 100, false, false, null, false, 1 ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithCustomListener( "ln",
-        false, 100, 100, false, false, null, false, 1 ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithCustomListener( "ln",
-        false, 100, 100, false, false, null, false, 1 ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithCustomListener( "ln",
-        false, 100, 100, false, false, null, false, 1 ));
 
+    vm1.invoke(createReplicatedRegionRunnable());
+    vm2.invoke(createReplicatedRegionRunnable());
+    vm3.invoke(createReplicatedRegionRunnable());
     vm4.invoke(createReplicatedRegionRunnable());
-    vm5.invoke(createReplicatedRegionRunnable());
-    vm6.invoke(createReplicatedRegionRunnable());
-    vm7.invoke(createReplicatedRegionRunnable());
     
+    vm1
+        .invoke(pauseAsyncEventQueueRunnable());
+    vm2
+        .invoke(pauseAsyncEventQueueRunnable());
+    vm3
+        .invoke(pauseAsyncEventQueueRunnable());
     vm4
-        .invoke(pauseAsyncEventQueueRunnable());
-    vm5
-        .invoke(pauseAsyncEventQueueRunnable());
-    vm6
-        .invoke(pauseAsyncEventQueueRunnable());
-    vm7
         .invoke(pauseAsyncEventQueueRunnable());
     Wait.pause(2000);// pause at least for the batchTimeInterval
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
         100 ));
     
+    vm1.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
     vm4.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateCustomAsyncEventListener( "ln", 100 ));// primary sender
-    vm5.invoke(() -> AsyncEventQueueTestBase.validateCustomAsyncEventListener( "ln", 0 ));// secondary
-    vm6.invoke(() -> AsyncEventQueueTestBase.validateCustomAsyncEventListener( "ln", 0 ));// secondary
-    vm7.invoke(() -> AsyncEventQueueTestBase.validateCustomAsyncEventListener( "ln", 0 ));// secondary
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateCustomAsyncEventListener( "ln", 100 ));// primary sender
+    vm2.invoke(() -> AsyncEventQueueTestBase.validateCustomAsyncEventListener( "ln", 0 ));// secondary
+    vm3.invoke(() -> AsyncEventQueueTestBase.validateCustomAsyncEventListener( "ln", 0 ));// secondary
+    vm4.invoke(() -> AsyncEventQueueTestBase.validateCustomAsyncEventListener( "ln", 0 ));// secondary
   }
 
   /**
@@ -312,32 +312,32 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
   public void testReplicatedSerialAsyncEventQueueWithConflationEnabled() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
+    vm3.invoke(createCacheRunnable(lnPort));
     vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
-    vm6.invoke(createCacheRunnable(lnPort));
-    vm7.invoke(createCacheRunnable(lnPort));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        false, 100, 100, true, false, null, false ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        false, 100, 100, true, false, null, false ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        false, 100, 100, true, false, null, false ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
         false, 100, 100, true, false, null, false ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        false, 100, 100, true, false, null, false ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        false, 100, 100, true, false, null, false ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        false, 100, 100, true, false, null, false ));
 
+    vm1.invoke(createReplicatedRegionRunnable());
+    vm2.invoke(createReplicatedRegionRunnable());
+    vm3.invoke(createReplicatedRegionRunnable());
     vm4.invoke(createReplicatedRegionRunnable());
-    vm5.invoke(createReplicatedRegionRunnable());
-    vm6.invoke(createReplicatedRegionRunnable());
-    vm7.invoke(createReplicatedRegionRunnable());
 
+    vm1
+        .invoke(pauseAsyncEventQueueRunnable());
+    vm2
+        .invoke(pauseAsyncEventQueueRunnable());
+    vm3
+        .invoke(pauseAsyncEventQueueRunnable());
     vm4
-        .invoke(pauseAsyncEventQueueRunnable());
-    vm5
-        .invoke(pauseAsyncEventQueueRunnable());
-    vm6
-        .invoke(pauseAsyncEventQueueRunnable());
-    vm7
         .invoke(pauseAsyncEventQueueRunnable());
     Wait.pause(1000);// pause at least for the batchTimeInterval
 
@@ -347,11 +347,11 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
       keyValues.put(i, i);
     }
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue(
+    vm1.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue(
         getTestMethodName() + "_RR", keyValues ));
 
     Wait.pause(1000);
-    vm4.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueSize(
+    vm1.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueSize(
         "ln", keyValues.size() ));
 
     for (int i = 0; i < 500; i++) {
@@ -360,29 +360,29 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
 
     // Put the update events and check the queue size.
     // There should be no conflation with the previous create events.
-    vm4.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue(
+    vm1.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue(
         getTestMethodName() + "_RR", updateKeyValues ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueSize(
+    vm1.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueSize(
         "ln", keyValues.size() + updateKeyValues.size() ));
 
     // Put the update events again and check the queue size.
     // There should be conflation with the previous update events.
-    vm4.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue(
+    vm1.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue(
         getTestMethodName() + "_RR", updateKeyValues ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueSize(
+    vm1.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueSize(
         "ln", keyValues.size() + updateKeyValues.size() ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
     vm4.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 1000 ));// primary sender
-    vm5.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
-    vm6.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
-    vm7.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 1000 ));// primary sender
+    vm2.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm3.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
   }
 
   
@@ -398,28 +398,28 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
   @Ignore("Disabled until I can sort out the hydra dependencies - see bug 52214")
   public void DISABLED_testReplicatedSerialAsyncEventQueueWithoutLocator() {
     int mPort = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    vm1.invoke(() -> AsyncEventQueueTestBase.createCacheWithoutLocator( mPort ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createCacheWithoutLocator( mPort ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createCacheWithoutLocator( mPort ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createCacheWithoutLocator( mPort ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createCacheWithoutLocator( mPort ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createCacheWithoutLocator( mPort ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createCacheWithoutLocator( mPort ));
 
+    vm1.invoke(createAsyncEventQueueRunnable());
+    vm2.invoke(createAsyncEventQueueRunnable());
+    vm3.invoke(createAsyncEventQueueRunnable());
     vm4.invoke(createAsyncEventQueueRunnable());
-    vm5.invoke(createAsyncEventQueueRunnable());
-    vm6.invoke(createAsyncEventQueueRunnable());
-    vm7.invoke(createAsyncEventQueueRunnable());
 
+    vm1.invoke(createReplicatedRegionRunnable());
+    vm2.invoke(createReplicatedRegionRunnable());
+    vm3.invoke(createReplicatedRegionRunnable());
     vm4.invoke(createReplicatedRegionRunnable());
-    vm5.invoke(createReplicatedRegionRunnable());
-    vm6.invoke(createReplicatedRegionRunnable());
-    vm7.invoke(createReplicatedRegionRunnable());
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
         1000 ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 1000 ));// primary sender
-    vm5.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
-    vm6.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
-    vm7.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 1000 ));// primary sender
+    vm2.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm3.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
   }
 
   /**
@@ -434,31 +434,31 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
   public void testReplicatedSerialAsyncEventQueueWithPeristenceEnabled() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
+    vm3.invoke(createCacheRunnable(lnPort));
     vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
-    vm6.invoke(createCacheRunnable(lnPort));
-    vm7.invoke(createCacheRunnable(lnPort));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        false, 100, 100, true, false, null, false ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        false, 100, 100, true, false, null, false ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        false, 100, 100, true, false, null, false ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
         false, 100, 100, true, false, null, false ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        false, 100, 100, true, false, null, false ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        false, 100, 100, true, false, null, false ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        false, 100, 100, true, false, null, false ));
 
+    vm1.invoke(createReplicatedRegionRunnable());
+    vm2.invoke(createReplicatedRegionRunnable());
+    vm3.invoke(createReplicatedRegionRunnable());
     vm4.invoke(createReplicatedRegionRunnable());
-    vm5.invoke(createReplicatedRegionRunnable());
-    vm6.invoke(createReplicatedRegionRunnable());
-    vm7.invoke(createReplicatedRegionRunnable());
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
         1000 ));
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 1000 ));// primary sender
-    vm5.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
-    vm6.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
-    vm7.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 1000 ));// primary sender
+    vm2.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm3.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
   }
 
   /**
@@ -474,32 +474,32 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
   public void DISABLED_testReplicatedSerialAsyncEventQueueWithPeristenceEnabled_Restart() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
+    vm3.invoke(createCacheRunnable(lnPort));
     vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
-    vm6.invoke(createCacheRunnable(lnPort));
-    vm7.invoke(createCacheRunnable(lnPort));
 
-    String firstDStore = (String)vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithDiskStore( "ln", false, 100,
+    String firstDStore = (String)vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithDiskStore( "ln", false, 100,
             100, true, null ));
 
-    vm4.invoke(createReplicatedRegionRunnable());
+    vm1.invoke(createReplicatedRegionRunnable());
 
     // pause async channel and then do the puts
-    vm4
+    vm1
         .invoke(pauseAsyncEventQueueRunnable());
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
         1000 ));
 
-    // ------------------ KILL VM4 AND REBUILD
+    // ------------------ KILL vm1 AND REBUILD
     // ------------------------------------------
-    vm4.invoke(() -> AsyncEventQueueTestBase.killSender());
+    vm1.invoke(() -> AsyncEventQueueTestBase.killSender());
 
-    vm4.invoke(createCacheRunnable(lnPort));
-    vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithDiskStore( "ln", false, 100, 100, true, firstDStore ));
-    vm4.invoke(createReplicatedRegionRunnable());
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithDiskStore( "ln", false, 100, 100, true, firstDStore ));
+    vm1.invoke(createReplicatedRegionRunnable());
     // -----------------------------------------------------------------------------------
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 1000 ));// primary sender
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 1000 ));// primary sender
   }
 
   /**
@@ -514,36 +514,36 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
   public void DISABLED_testReplicatedSerialAsyncEventQueueWithPeristenceEnabled_Restart2() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
-    vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
-    vm6.invoke(createCacheRunnable(lnPort));
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
+    vm3.invoke(createCacheRunnable(lnPort));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithDiskStore( "ln", false, 100, 100, true, null ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithDiskStore( "ln", false, 100, 100, true, null ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithDiskStore( "ln", false, 100, 100, true, null ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithDiskStore( "ln", false, 100, 100, true, null ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithDiskStore( "ln", false, 100, 100, true, null ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithDiskStore( "ln", false, 100, 100, true, null ));
 
-    vm4.invoke(createReplicatedRegionRunnable());
-    vm4.invoke(() -> AsyncEventQueueTestBase.addCacheListenerAndCloseCache( getTestMethodName() + "_RR" ));
-    vm5.invoke(createReplicatedRegionRunnable());
-    vm6.invoke(createReplicatedRegionRunnable());
+    vm1.invoke(createReplicatedRegionRunnable());
+    vm1.invoke(() -> AsyncEventQueueTestBase.addCacheListenerAndCloseCache( getTestMethodName() + "_RR" ));
+    vm2.invoke(createReplicatedRegionRunnable());
+    vm3.invoke(createReplicatedRegionRunnable());
 
-    vm5.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR", 2000 ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR", 2000 ));
 
     // -----------------------------------------------------------------------------------
-    vm5.invoke(() -> AsyncEventQueueTestBase.waitForSenderToBecomePrimary( AsyncEventQueueImpl
+    vm2.invoke(() -> AsyncEventQueueTestBase.waitForSenderToBecomePrimary( AsyncEventQueueImpl
             .getSenderIdFromAsyncEventQueueId("ln") ));
     
-    vm5.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
 
-    int vm4size = (Integer)vm4.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln" ));
-    int vm5size = (Integer)vm5.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln" ));
+    int vm1size = (Integer)vm1.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln" ));
+    int vm2size = (Integer)vm2.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln" ));
 
-    LogWriterUtils.getLogWriter().info("vm4 size is: " + vm4size);
-    LogWriterUtils.getLogWriter().info("vm5 size is: " + vm5size);
+    LogWriterUtils.getLogWriter().info("vm1 size is: " + vm1size);
+    LogWriterUtils.getLogWriter().info("vm2 size is: " + vm2size);
     // verify that there is no event loss
     assertTrue(
-        "Total number of entries in events map on vm4 and vm5 should be at least 2000",
-        (vm4size + vm5size) >= 2000);
+        "Total number of entries in events map on vm1 and vm2 should be at least 2000",
+        (vm1size + vm2size) >= 2000);
   }
   
   /**
@@ -557,31 +557,31 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
   public void testConcurrentSerialAsyncEventQueueWithReplicatedRegion() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
+    vm3.invoke(createCacheRunnable(lnPort));
     vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
-    vm6.invoke(createCacheRunnable(lnPort));
-    vm7.invoke(createCacheRunnable(lnPort));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+        false, 100, 100, true, false, null, false, 3, OrderPolicy.KEY ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+        false, 100, 100, true, false, null, false, 3, OrderPolicy.KEY ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+        false, 100, 100, true, false, null, false, 3, OrderPolicy.KEY ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
         false, 100, 100, true, false, null, false, 3, OrderPolicy.KEY ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
-        false, 100, 100, true, false, null, false, 3, OrderPolicy.KEY ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
-        false, 100, 100, true, false, null, false, 3, OrderPolicy.KEY ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
-        false, 100, 100, true, false, null, false, 3, OrderPolicy.KEY ));
 
+    vm1.invoke(createReplicatedRegionRunnable());
+    vm2.invoke(createReplicatedRegionRunnable());
+    vm3.invoke(createReplicatedRegionRunnable());
     vm4.invoke(createReplicatedRegionRunnable());
-    vm5.invoke(createReplicatedRegionRunnable());
-    vm6.invoke(createReplicatedRegionRunnable());
-    vm7.invoke(createReplicatedRegionRunnable());
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
         1000 ));
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener("ln", 1000 ));// primary sender
-    vm5.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener("ln", 0 ));// secondary
-    vm6.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener("ln", 0 ));// secondary
-    vm7.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener("ln", 0 ));// secondary
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener("ln", 1000 ));// primary sender
+    vm2.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener("ln", 0 ));// secondary
+    vm3.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener("ln", 0 ));// secondary
+    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener("ln", 0 ));// secondary
   }
   
   /**
@@ -595,37 +595,37 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
   public void testConcurrentSerialAsyncEventQueueWithReplicatedRegion_2() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
+    vm3.invoke(createCacheRunnable(lnPort));
     vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
-    vm6.invoke(createCacheRunnable(lnPort));
-    vm7.invoke(createCacheRunnable(lnPort));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+        false, 100, 100, true, false, null, false, 3, OrderPolicy.THREAD ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+        false, 100, 100, true, false, null, false, 3, OrderPolicy.THREAD ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+        false, 100, 100, true, false, null, false, 3, OrderPolicy.THREAD ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
         false, 100, 100, true, false, null, false, 3, OrderPolicy.THREAD ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
-        false, 100, 100, true, false, null, false, 3, OrderPolicy.THREAD ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
-        false, 100, 100, true, false, null, false, 3, OrderPolicy.THREAD ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
-        false, 100, 100, true, false, null, false, 3, OrderPolicy.THREAD ));
 
+    vm1.invoke(createReplicatedRegionRunnable());
+    vm2.invoke(createReplicatedRegionRunnable());
+    vm3.invoke(createReplicatedRegionRunnable());
     vm4.invoke(createReplicatedRegionRunnable());
-    vm5.invoke(createReplicatedRegionRunnable());
-    vm6.invoke(createReplicatedRegionRunnable());
-    vm7.invoke(createReplicatedRegionRunnable());
 
-    vm4.invokeAsync(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
+    vm1.invokeAsync(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
         500 ));
-    vm4.invokeAsync(() -> AsyncEventQueueTestBase.doNextPuts( getTestMethodName() + "_RR",
+    vm1.invokeAsync(() -> AsyncEventQueueTestBase.doNextPuts( getTestMethodName() + "_RR",
       500, 1000 ));
     //Async invocation which was bound to fail
-//    vm4.invokeAsync(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
+//    vm1.invokeAsync(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
 //      1000, 1500 ));
     
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener("ln", 1000 ));// primary sender
-    vm5.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener("ln", 0 ));// secondary
-    vm6.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener("ln", 0 ));// secondary
-    vm7.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener("ln", 0 ));// secondary
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener("ln", 1000 ));// primary sender
+    vm2.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener("ln", 0 ));// secondary
+    vm3.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener("ln", 0 ));// secondary
+    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener("ln", 0 ));// secondary
   }
   
   /**
@@ -635,31 +635,31 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
   public void testConcurrentSerialAsyncEventQueueWithoutOrderPolicy() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
+    vm3.invoke(createCacheRunnable(lnPort));
     vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
-    vm6.invoke(createCacheRunnable(lnPort));
-    vm7.invoke(createCacheRunnable(lnPort));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+        false, 100, 100, true, false, null, false, 3, null ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+        false, 100, 100, true, false, null, false, 3, null ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+        false, 100, 100, true, false, null, false, 3, null ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
         false, 100, 100, true, false, null, false, 3, null ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
-        false, 100, 100, true, false, null, false, 3, null ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
-        false, 100, 100, true, false, null, false, 3, null ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
-        false, 100, 100, true, false, null, false, 3, null ));
 
+    vm1.invoke(createReplicatedRegionRunnable());
+    vm2.invoke(createReplicatedRegionRunnable());
+    vm3.invoke(createReplicatedRegionRunnable());
     vm4.invoke(createReplicatedRegionRunnable());
-    vm5.invoke(createReplicatedRegionRunnable());
-    vm6.invoke(createReplicatedRegionRunnable());
-    vm7.invoke(createReplicatedRegionRunnable());
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
         1000 ));
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener("ln", 1000 ));// primary sender
-    vm5.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener("ln", 0 ));// secondary
-    vm6.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener("ln", 0 ));// secondary
-    vm7.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener("ln", 0 ));// secondary
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener("ln", 1000 ));// primary sender
+    vm2.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener("ln", 0 ));// secondary
+    vm3.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener("ln", 0 ));// secondary
+    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener("ln", 0 ));// secondary
   }
 
   /**
@@ -671,29 +671,29 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
   public void testPartitionedSerialAsyncEventQueue() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
+    vm3.invoke(createCacheRunnable(lnPort));
     vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
-    vm6.invoke(createCacheRunnable(lnPort));
-    vm7.invoke(createCacheRunnable(lnPort));
 
+    vm1.invoke(createAsyncEventQueueRunnable());
+    vm2.invoke(createAsyncEventQueueRunnable());
+    vm3.invoke(createAsyncEventQueueRunnable());
     vm4.invoke(createAsyncEventQueueRunnable());
-    vm5.invoke(createAsyncEventQueueRunnable());
-    vm6.invoke(createAsyncEventQueueRunnable());
-    vm7.invoke(createAsyncEventQueueRunnable());
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR",
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR",
         500 ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.doPutsFrom(
+    vm2.invoke(() -> AsyncEventQueueTestBase.doPutsFrom(
         getTestMethodName() + "_PR", 500, 1000 ));
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 1000 ));// primary sender
-    vm5.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
-    vm6.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
-    vm7.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 1000 ));// primary sender
+    vm2.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm3.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
   }
 
   /**
@@ -705,32 +705,32 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
   public void testPartitionedSerialAsyncEventQueueWithConflationEnabled() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
+    vm3.invoke(createCacheRunnable(lnPort));
     vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
-    vm6.invoke(createCacheRunnable(lnPort));
-    vm7.invoke(createCacheRunnable(lnPort));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        false, 100, 100, true, false, null, false ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        false, 100, 100, true, false, null, false ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        false, 100, 100, true, false, null, false ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
         false, 100, 100, true, false, null, false ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        false, 100, 100, true, false, null, false ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        false, 100, 100, true, false, null, false ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        false, 100, 100, true, false, null, false ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
 
+    vm1
+        .invoke(pauseAsyncEventQueueRunnable());
+    vm2
+        .invoke(pauseAsyncEventQueueRunnable());
+    vm3
+        .invoke(pauseAsyncEventQueueRunnable());
     vm4
-        .invoke(pauseAsyncEventQueueRunnable());
-    vm5
-        .invoke(pauseAsyncEventQueueRunnable());
-    vm6
-        .invoke(pauseAsyncEventQueueRunnable());
-    vm7
         .invoke(pauseAsyncEventQueueRunnable());
     
     Wait.pause(2000);
@@ -741,10 +741,10 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
       keyValues.put(i, i);
     }
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue(
+    vm1.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue(
         getTestMethodName() + "_PR", keyValues ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueSize(
+    vm1.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueSize(
         "ln", keyValues.size() ));
 
     for (int i = 0; i < 500; i++) {
@@ -753,29 +753,29 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
 
     // Put the update events and check the queue size.
     // There should be no conflation with the previous create events.
-    vm5.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue(
+    vm2.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue(
         getTestMethodName() + "_PR", updateKeyValues ));
 
-    vm5.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueSize(
+    vm2.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueSize(
         "ln", keyValues.size() + updateKeyValues.size() ));
 
     // Put the update events again and check the queue size.
     // There should be conflation with the previous update events.
-    vm5.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue(
+    vm2.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue(
       getTestMethodName() + "_PR", updateKeyValues ));
 
-    vm5.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueSize(
+    vm2.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueSize(
       "ln", keyValues.size() + updateKeyValues.size() ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
     vm4.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 1000 ));// primary sender
-    vm5.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
-    vm6.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
-    vm7.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 1000 ));// primary sender
+    vm2.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm3.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
   }
 
   /**
@@ -789,33 +789,33 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
   public void testPartitionedSerialAsyncEventQueueWithPeristenceEnabled() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
+    vm3.invoke(createCacheRunnable(lnPort));
     vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
-    vm6.invoke(createCacheRunnable(lnPort));
-    vm7.invoke(createCacheRunnable(lnPort));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        false, 100, 100, false, true, null, false ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        false, 100, 100, false, true, null, false ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        false, 100, 100, false, true, null, false ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
         false, 100, 100, false, true, null, false ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        false, 100, 100, false, true, null, false ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        false, 100, 100, false, true, null, false ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        false, 100, 100, false, true, null, false ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR",
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR",
         500 ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.doPutsFrom(
+    vm2.invoke(() -> AsyncEventQueueTestBase.doPutsFrom(
         getTestMethodName() + "_PR", 500, 1000 ));
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 1000 ));// primary sender
-    vm5.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
-    vm6.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
-    vm7.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 1000 ));// primary sender
+    vm2.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm3.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
   }
 
   /**
@@ -829,54 +829,54 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
   public void testPartitionedSerialAsyncEventQueueWithPeristenceEnabled_Restart() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
+    vm3.invoke(createCacheRunnable(lnPort));
     vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
-    vm6.invoke(createCacheRunnable(lnPort));
-    vm7.invoke(createCacheRunnable(lnPort));
 
-    String firstDStore = (String)vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithDiskStore( "ln", false, 100,
+    String firstDStore = (String)vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithDiskStore( "ln", false, 100,
             100, true, null ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
 
     // pause async channel and then do the puts
-    vm4
+    vm1
         .invoke(() -> AsyncEventQueueTestBase.pauseAsyncEventQueueAndWaitForDispatcherToPause( "ln" ));
   
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR",
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR",
         1000 ));
 
-    // ------------------ KILL VM4 AND REBUILD
+    // ------------------ KILL vm1 AND REBUILD
     // ------------------------------------------
-    vm4.invoke(() -> AsyncEventQueueTestBase.killSender());
+    vm1.invoke(() -> AsyncEventQueueTestBase.killSender());
 
-    vm4.invoke(createCacheRunnable(lnPort));
-    vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithDiskStore( "ln", false, 100, 100, true, firstDStore ));
-    vm4.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithDiskStore( "ln", false, 100, 100, true, firstDStore ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
     // -----------------------------------------------------------------------------------
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 1000 ));// primary sender
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 1000 ));// primary sender
   }
 
   public void testParallelAsyncEventQueueWithReplicatedRegion() {
     try {
       Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+      vm1.invoke(createCacheRunnable(lnPort));
+      vm2.invoke(createCacheRunnable(lnPort));
+      vm3.invoke(createCacheRunnable(lnPort));
       vm4.invoke(createCacheRunnable(lnPort));
-      vm5.invoke(createCacheRunnable(lnPort));
-      vm6.invoke(createCacheRunnable(lnPort));
-      vm7.invoke(createCacheRunnable(lnPort));
 
+      vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue(
+          "ln", true, 100, 100, true, false, null, false ));
+      vm2.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue(
+          "ln", true, 100, 100, true, false, null, false ));
+      vm3.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue(
+          "ln", true, 100, 100, true, false, null, false ));
       vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue(
           "ln", true, 100, 100, true, false, null, false ));
-      vm5.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue(
-          "ln", true, 100, 100, true, false, null, false ));
-      vm6.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue(
-          "ln", true, 100, 100, true, false, null, false ));
-      vm7.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue(
-          "ln", true, 100, 100, true, false, null, false ));
 
-      vm4.invoke(createReplicatedRegionRunnable());
+      vm1.invoke(createReplicatedRegionRunnable());
       fail("Expected GatewaySenderConfigException where parallel async event queue can not be used with replicated region");
     }
     catch (Exception e) {
@@ -890,77 +890,77 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
   public void testParallelAsyncEventQueue() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
+    vm3.invoke(createCacheRunnable(lnPort));
     vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
-    vm6.invoke(createCacheRunnable(lnPort));
-    vm7.invoke(createCacheRunnable(lnPort));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        true, 100, 100, false, false, null, false ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        true, 100, 100, false, false, null, false ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        true, 100, 100, false, false, null, false ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
         true, 100, 100, false, false, null, false ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        true, 100, 100, false, false, null, false ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        true, 100, 100, false, false, null, false ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        true, 100, 100, false, false, null, false ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR",
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR",
         256 ));
     
+    vm1.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
     vm4.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
     
+    int vm1size = (Integer)vm1.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
+    int vm2size = (Integer)vm2.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
+    int vm3size = (Integer)vm3.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
     int vm4size = (Integer)vm4.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
-    int vm5size = (Integer)vm5.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
-    int vm6size = (Integer)vm6.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
-    int vm7size = (Integer)vm7.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
     
-    assertEquals(vm4size + vm5size + vm6size + vm7size, 256);
+    assertEquals(vm1size + vm2size + vm3size + vm4size, 256);
   }
 
   public void testParallelAsyncEventQueueWithSubstitutionFilter() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
-    vm4.invoke(createCacheRunnable(lnPort));
+    vm1.invoke(createCacheRunnable(lnPort));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
         true, 100, 100, false, false, null, false, "MyAsyncEventListener", "MyGatewayEventSubstitutionFilter" ));
 
     String regionName = getTestMethodName() + "_PR";
-    vm4.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( regionName, "ln", isOffHeap() ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( regionName, "ln", isOffHeap() ));
 
     int numPuts = 10;
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( regionName, numPuts ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( regionName, numPuts ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
 
-    vm4.invoke(() -> verifySubstitutionFilterInvocations( "ln" ,numPuts ));
+    vm1.invoke(() -> verifySubstitutionFilterInvocations( "ln" ,numPuts ));
   }
 
   public void testParallelAsyncEventQueueWithSubstitutionFilterNoSubstituteValueToDataInvocations() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
-    vm4.invoke(createCacheRunnable(lnPort));
+    vm1.invoke(createCacheRunnable(lnPort));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
         true, 100, 100, false, false, null, false, "MyAsyncEventListener", "SizeableGatewayEventSubstitutionFilter" ));
 
     String regionName = getTestMethodName() + "_PR";
-    vm4.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( regionName, "ln", isOffHeap() ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( regionName, "ln", isOffHeap() ));
 
     int numPuts = 10;
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( regionName, numPuts ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( regionName, numPuts ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
 
-    vm4.invoke(() -> verifySubstitutionFilterToDataInvocations( "ln" ,0 ));
+    vm1.invoke(() -> verifySubstitutionFilterToDataInvocations( "ln" ,0 ));
   }
 
   /**
@@ -970,73 +970,73 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
   public void testParallelAsyncEventQueueWithCacheLoader() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
+    vm3.invoke(createCacheRunnable(lnPort));
     vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
-    vm6.invoke(createCacheRunnable(lnPort));
-    vm7.invoke(createCacheRunnable(lnPort));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+    	true, 100, 100, false, false, null, false, "MyAsyncEventListener_CacheLoader" ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+    	true, 100, 100, false, false, null, false, "MyAsyncEventListener_CacheLoader" ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+    	true, 100, 100, false, false, null, false, "MyAsyncEventListener_CacheLoader" ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
     	true, 100, 100, false, false, null, false, "MyAsyncEventListener_CacheLoader" ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-    	true, 100, 100, false, false, null, false, "MyAsyncEventListener_CacheLoader" ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-    	true, 100, 100, false, false, null, false, "MyAsyncEventListener_CacheLoader" ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-    	true, 100, 100, false, false, null, false, "MyAsyncEventListener_CacheLoader" ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithCacheLoaderAndAsyncQueue( getTestMethodName() + "_PR", "ln" ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithCacheLoaderAndAsyncQueue( getTestMethodName() + "_PR", "ln" ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithCacheLoaderAndAsyncQueue( getTestMethodName() + "_PR", "ln" ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithCacheLoaderAndAsyncQueue( getTestMethodName() + "_PR", "ln" ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithCacheLoaderAndAsyncQueue( getTestMethodName() + "_PR", "ln" ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithCacheLoaderAndAsyncQueue( getTestMethodName() + "_PR", "ln" ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithCacheLoaderAndAsyncQueue( getTestMethodName() + "_PR", "ln" ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPutAll( getTestMethodName() + "_PR",
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPutAll( getTestMethodName() + "_PR",
     	100, 10 ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventForOperationDetail( "ln", 250, false, true ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventForOperationDetail( "ln", 250, false, true ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventForOperationDetail( "ln", 250, false, true ));
     vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventForOperationDetail( "ln", 250, false, true ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventForOperationDetail( "ln", 250, false, true ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventForOperationDetail( "ln", 250, false, true ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventForOperationDetail( "ln", 250, false, true ));
   }
   
   public void testParallelAsyncEventQueueSize() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
+    vm3.invoke(createCacheRunnable(lnPort));
     vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
-    vm6.invoke(createCacheRunnable(lnPort));
-    vm7.invoke(createCacheRunnable(lnPort));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        true, 100, 100, false, false, null, false ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        true, 100, 100, false, false, null, false ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        true, 100, 100, false, false, null, false ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
         true, 100, 100, false, false, null, false ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        true, 100, 100, false, false, null, false ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        true, 100, 100, false, false, null, false ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        true, 100, 100, false, false, null, false ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
 
+    vm1
+        .invoke(pauseAsyncEventQueueRunnable());
+    vm2
+        .invoke(pauseAsyncEventQueueRunnable());
+    vm3
+        .invoke(pauseAsyncEventQueueRunnable());
     vm4
-        .invoke(pauseAsyncEventQueueRunnable());
-    vm5
-        .invoke(pauseAsyncEventQueueRunnable());
-    vm6
-        .invoke(pauseAsyncEventQueueRunnable());
-    vm7
         .invoke(pauseAsyncEventQueueRunnable());
     Wait.pause(1000);// pause at least for the batchTimeInterval
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR",
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR",
         1000 ));
 
-    int vm4size = (Integer)vm4.invoke(() -> AsyncEventQueueTestBase.getAsyncEventQueueSize( "ln" ));
-    int vm5size = (Integer)vm5.invoke(() -> AsyncEventQueueTestBase.getAsyncEventQueueSize( "ln" ));
+    int vm1size = (Integer)vm1.invoke(() -> AsyncEventQueueTestBase.getAsyncEventQueueSize( "ln" ));
+    int vm2size = (Integer)vm2.invoke(() -> AsyncEventQueueTestBase.getAsyncEventQueueSize( "ln" ));
     
-    assertEquals("Size of AsyncEventQueue is incorrect", 1000, vm4size);
-    assertEquals("Size of AsyncEventQueue is incorrect", 1000, vm5size);
+    assertEquals("Size of AsyncEventQueue is incorrect", 1000, vm1size);
+    assertEquals("Size of AsyncEventQueue is incorrect", 1000, vm2size);
   }
   
   /**
@@ -1046,74 +1046,74 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
   public void testConcurrentParallelAsyncEventQueueSize() {
 	Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+	vm1.invoke(createCacheRunnable(lnPort));
+	vm2.invoke(createCacheRunnable(lnPort));
+	vm3.invoke(createCacheRunnable(lnPort));
 	vm4.invoke(createCacheRunnable(lnPort));
-	vm5.invoke(createCacheRunnable(lnPort));
-	vm6.invoke(createCacheRunnable(lnPort));
-	vm7.invoke(createCacheRunnable(lnPort));
 
+	vm1.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+	  true, 100, 100, false, false, null, false, 2, OrderPolicy.KEY ));
+	vm2.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+	  true, 100, 100, false, false, null, false, 2, OrderPolicy.KEY ));
+	vm3.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+	  true, 100, 100, false, false, null, false, 2, OrderPolicy.KEY ));
 	vm4.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
 	  true, 100, 100, false, false, null, false, 2, OrderPolicy.KEY ));
-	vm5.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
-	  true, 100, 100, false, false, null, false, 2, OrderPolicy.KEY ));
-	vm6.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
-	  true, 100, 100, false, false, null, false, 2, OrderPolicy.KEY ));
-	vm7.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
-	  true, 100, 100, false, false, null, false, 2, OrderPolicy.KEY ));
 
+	vm1.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+	vm2.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+	vm3.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
 	vm4.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-	vm5.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-	vm6.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-	vm7.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
 
+	vm1
+	  .invoke(pauseAsyncEventQueueRunnable());
+	vm2
+	  .invoke(pauseAsyncEventQueueRunnable());
+	vm3
+	  .invoke(pauseAsyncEventQueueRunnable());
 	vm4
-	  .invoke(pauseAsyncEventQueueRunnable());
-	vm5
-	  .invoke(pauseAsyncEventQueueRunnable());
-	vm6
-	  .invoke(pauseAsyncEventQueueRunnable());
-	vm7
 	  .invoke(pauseAsyncEventQueueRunnable());
 	Wait.pause(1000);// pause at least for the batchTimeInterval
 
-	vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR",
+	vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR",
 	  1000 ));
 
-	int vm4size = (Integer)vm4.invoke(() -> AsyncEventQueueTestBase.getAsyncEventQueueSize( "ln" ));
-	int vm5size = (Integer)vm5.invoke(() -> AsyncEventQueueTestBase.getAsyncEventQueueSize( "ln" ));
+	int vm1size = (Integer)vm1.invoke(() -> AsyncEventQueueTestBase.getAsyncEventQueueSize( "ln" ));
+	int vm2size = (Integer)vm2.invoke(() -> AsyncEventQueueTestBase.getAsyncEventQueueSize( "ln" ));
 	    
-	assertEquals("Size of AsyncEventQueue is incorrect", 1000, vm4size);
-	assertEquals("Size of AsyncEventQueue is incorrect", 1000, vm5size);
+	assertEquals("Size of AsyncEventQueue is incorrect", 1000, vm1size);
+	assertEquals("Size of AsyncEventQueue is incorrect", 1000, vm2size);
   }
   
   public void testParallelAsyncEventQueueWithConflationEnabled() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
+    vm3.invoke(createCacheRunnable(lnPort));
     vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
-    vm6.invoke(createCacheRunnable(lnPort));
-    vm7.invoke(createCacheRunnable(lnPort));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        true, 100, 100, true, false, null, false ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        true, 100, 100, true, false, null, false ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        true, 100, 100, true, false, null, false ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
         true, 100, 100, true, false, null, false ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        true, 100, 100, true, false, null, false ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        true, 100, 100, true, false, null, false ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        true, 100, 100, true, false, null, false ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
 
+    vm1
+        .invoke(pauseAsyncEventQueueRunnable());
+    vm2
+        .invoke(pauseAsyncEventQueueRunnable());
+    vm3
+        .invoke(pauseAsyncEventQueueRunnable());
     vm4
-        .invoke(pauseAsyncEventQueueRunnable());
-    vm5
-        .invoke(pauseAsyncEventQueueRunnable());
-    vm6
-        .invoke(pauseAsyncEventQueueRunnable());
-    vm7
         .invoke(pauseAsyncEventQueueRunnable());
 
     Wait.pause(2000);// pause for the batchTimeInterval to ensure that all the
@@ -1125,45 +1125,45 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
       keyValues.put(i, i);
     }
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue(
+    vm1.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue(
         getTestMethodName() + "_PR", keyValues ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueSize(
+    vm1.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueSize(
         "ln", keyValues.size() ));
 
     for (int i = 0; i < 500; i++) {
       updateKeyValues.put(i, i + "_updated");
     }
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue(
+    vm1.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue(
         getTestMethodName() + "_PR", updateKeyValues ));
 
  
-    vm4.invoke(() -> AsyncEventQueueTestBase.waitForAsyncEventQueueSize(
+    vm1.invoke(() -> AsyncEventQueueTestBase.waitForAsyncEventQueueSize(
         "ln", keyValues.size() + updateKeyValues.size() )); // no conflation of creates
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue(
+    vm1.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue(
         getTestMethodName() + "_PR", updateKeyValues ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.waitForAsyncEventQueueSize(
+    vm1.invoke(() -> AsyncEventQueueTestBase.waitForAsyncEventQueueSize(
         "ln", keyValues.size() + updateKeyValues.size() )); // conflation of updates
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
     vm4.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
     vm4.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
     
+    int vm1size = (Integer)vm1.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
+    int vm2size = (Integer)vm2.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
+    int vm3size = (Integer)vm3.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
     int vm4size = (Integer)vm4.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
-    int vm5size = (Integer)vm5.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
-    int vm6size = (Integer)vm6.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
-    int vm7size = (Integer)vm7.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
     
-    assertEquals(vm4size + vm5size + vm6size + vm7size, keyValues.size());
+    assertEquals(vm1size + vm2size + vm3size + vm4size, keyValues.size());
   }
 
   /**
@@ -1172,33 +1172,29 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
   public void testParallelAsyncEventQueueWithConflationEnabled_bug47213() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
+    vm3.invoke(createCacheRunnable(lnPort));
     vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
-    vm6.invoke(createCacheRunnable(lnPort));
-    vm7.invoke(createCacheRunnable(lnPort));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        true, 100, 100, true, false, null, false ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        true, 100, 100, true, false, null, false ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        true, 100, 100, true, false, null, false ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
         true, 100, 100, true, false, null, false ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        true, 100, 100, true, false, null, false ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        true, 100, 100, true, false, null, false ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        true, 100, 100, true, false, null, false ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createPRWithRedundantCopyWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createPRWithRedundantCopyWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createPRWithRedundantCopyWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createPRWithRedundantCopyWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createPRWithRedundantCopyWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createPRWithRedundantCopyWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createPRWithRedundantCopyWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
 
-    vm4
-        .invoke(pauseAsyncEventQueueRunnable());
-    vm5
-        .invoke(pauseAsyncEventQueueRunnable());
-    vm6
-        .invoke(pauseAsyncEventQueueRunnable());
-    vm7
-        .invoke(pauseAsyncEventQueueRunnable());
+    vm1.invoke(pauseAsyncEventQueueRunnable());
+    vm2.invoke(pauseAsyncEventQueueRunnable());
+    vm3.invoke(pauseAsyncEventQueueRunnable());
+    vm4.invoke(pauseAsyncEventQueueRunnable());
 
     Wait.pause(2000);// pause for the batchTimeInterval to ensure that all the
     // senders are paused
@@ -1209,308 +1205,302 @@ public class AsyncEventListenerDUnitTest extends AsyncEventQueueTestBase {
       keyValues.put(i, i);
     }
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue(
+    vm1.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue(
         getTestMethodName() + "_PR", keyValues ));
 
     Wait.pause(2000);
-    vm4.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueSize(
+    vm1.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueSize(
         "ln", keyValues.size() ));
 
     for (int i = 0; i < 500; i++) {
       updateKeyValues.put(i, i + "_updated");
     }
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue(
+    vm1.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue(
         getTestMethodName() + "_PR", updateKeyValues ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue(
+    vm1.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue(
         getTestMethodName() + "_PR", updateKeyValues ));
 
     // pause to ensure that events have been conflated.
     Wait.pause(2000);
-    vm4.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueSize(
+    vm1.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueSize(
         "ln", keyValues.size() + updateKeyValues.size() ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
     vm4.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
     vm4.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
     
+    int vm1size = (Integer)vm1.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
+    int vm2size = (Integer)vm2.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
+    int vm3size = (Integer)vm3.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
     int vm4size = (Integer)vm4.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
-    int vm5size = (Integer)vm5.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
-    int vm6size = (Integer)vm6.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
-    int vm7size = (Integer)vm7.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
     
-    assertEquals(vm4size + vm5size + vm6size + vm7size, keyValues.size());
+    assertEquals(vm1size + vm2size + vm3size + vm4size, keyValues.size());
     
   }
 
   public void testParallelAsyncEventQueueWithOneAccessor() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
     vm3.invoke(createCacheRunnable(lnPort));
     vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
-    vm6.invoke(createCacheRunnable(lnPort));
-    vm7.invoke(createCacheRunnable(lnPort));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        true, 100, 100, false, false, null, false ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        true, 100, 100, false, false, null, false ));
     vm3.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
         true, 100, 100, false, false, null, false ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
         true, 100, 100, false, false, null, false ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        true, 100, 100, false, false, null, false ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        true, 100, 100, false, false, null, false ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        true, 100, 100, false, false, null, false ));
 
-    vm3.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionAccessorWithAsyncEventQueue(
+    vm1.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionAccessorWithAsyncEventQueue(
             getTestMethodName() + "_PR", "ln" ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
 
-    vm3.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR",
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR",
         256 ));
     
+    vm2.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
     vm4.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));
     
-    vm3.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));
-    
+    int vm2size = (Integer)vm2.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
+    int vm3size = (Integer)vm3.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
     int vm4size = (Integer)vm4.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
-    int vm5size = (Integer)vm5.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
-    int vm6size = (Integer)vm6.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
-    int vm7size = (Integer)vm7.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
-    
-    assertEquals(vm4size + vm5size + vm6size + vm7size, 256);
+
+    assertEquals(vm2size + vm3size + vm4size, 256);
 
   }
 
   public void testParallelAsyncEventQueueWithPersistence() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
+    vm3.invoke(createCacheRunnable(lnPort));
     vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
-    vm6.invoke(createCacheRunnable(lnPort));
-    vm7.invoke(createCacheRunnable(lnPort));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        true, 100, 100, false, true, null, false ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        true, 100, 100, false, true, null, false ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        true, 100, 100, false, true, null, false ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
         true, 100, 100, false, true, null, false ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        true, 100, 100, false, true, null, false ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        true, 100, 100, false, true, null, false ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        true, 100, 100, false, true, null, false ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR",
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR",
         256 ));
     
+    vm1.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
     vm4.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
     
+    int vm1size = (Integer)vm1.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
+    int vm2size = (Integer)vm2.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
+    int vm3size = (Integer)vm3.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
     int vm4size = (Integer)vm4.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
-    int vm5size = (Integer)vm5.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
-    int vm6size = (Integer)vm6.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
-    int vm7size = (Integer)vm7.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
     
-    assertEquals(vm4size + vm5size + vm6size + vm7size, 256);
+    assertEquals(vm1size + vm2size + vm3size + vm4size, 256);
   }
   
 /**
- * Test case to test possibleDuplicates. vm4 & vm5 are hosting the PR. vm5 is
- * killed so the buckets hosted by it are shifted to vm4.
+ * Test case to test possibleDuplicates. vm1 & vm2 are hosting the PR. vm2 is
+ * killed so the buckets hosted by it are shifted to vm1.
  */
   @Ignore("Disabled for 52349")
   public void DISABLED_testParallelAsyncEventQueueHA_Scenario1() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
-    vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
 
     LogWriterUtils.getLogWriter().info("Created the cache");
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithListener2( "ln", true, 100, 5, false, null ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithListener2( "ln", true, 100, 5, false, null ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithListener2( "ln", true, 100, 5, false, null ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithListener2( "ln", true, 100, 5, false, null ));
 
     LogWriterUtils.getLogWriter().info("Created the AsyncEventQueue");
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.createPRWithRedundantCopyWithAsyncEventQueue(
+    vm1.invoke(() -> AsyncEventQueueTestBase.createPRWithRedundantCopyWithAsyncEventQueue(
             getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createPRWithRedundantCopyWithAsyncEventQueue(
+    vm2.invoke(() -> AsyncEventQueueTestBase.createPRWithRedundantCopyWithAsyncEventQueue(
             getTestMethodName() + "_PR", "ln", isOffHeap() ));
 
     LogWriterUtils.getLogWriter().info("Created PR with AsyncEventQueue");
 
-    vm4
+    vm1
         .invoke(pauseAsyncEventQueueRunnable());
-    vm5
+    vm2
         .invoke(pauseAsyncEventQueueRunnable());
     Wait.pause(1000);// pause for the batchTimeInterval to make sure the AsyncQueue
                 // is paused
 
     LogWriterUtils.getLogWriter().info("Paused the AsyncEventQueue");
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR", 80 ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR", 80 ));
 
     LogWriterUtils.getLogWriter().info("Done puts");
 
-    Set<Integer> primaryBucketsVm5 = (Set<Integer>)vm5.invoke(() -> AsyncEventQueueTestBase.getAllPrimaryBucketsOnTheNode( getTestMethodName() + "_PR" ));
+    Set<Integer> primaryBucketsvm2 = (Set<Integer>)vm2.invoke(() -> AsyncEventQueueTestBase.getAllPrimaryBucketsOnTheNode( getTestMethodName() + "_PR" ));
 
-    LogWriterUtils.getLogWriter().info("Primary buckets on vm5: " + primaryBucketsVm5);
-    // ---------------------------- Kill vm5 --------------------------
-    vm5.invoke(() -> AsyncEventQueueTestBase.killSender());
+    LogWriterUtils.getLogWriter().info("Primary buckets on vm2: " + primaryBucketsvm2);
+    // ---------------------------- Kill vm2 --------------------------
+    vm2.invoke(() -> AsyncEventQueueTestBase.killSender());
 
     Wait.pause(1000);// give some time for rebalancing to happen
-    vm4.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.verifyAsyncEventListenerForPossibleDuplicates( "ln",
-            primaryBucketsVm5, 5 ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.verifyAsyncEventListenerForPossibleDuplicates( "ln",
+            primaryBucketsvm2, 5 ));
   }
 
   /**
-   * Test case to test possibleDuplicates. vm4 & vm5 are hosting the PR. vm5 is
-   * killed and subsequently vm6 is brought up. Buckets are now rebalanced
-   * between vm4 & vm6.
+   * Test case to test possibleDuplicates. vm1 & vm2 are hosting the PR. vm2 is
+   * killed and subsequently vm3 is brought up. Buckets are now rebalanced
+   * between vm1 & vm3.
    */
   @Category(FlakyTest.class) // GEODE-688 & GEODE-713: random ports, thread sleeps, async actions
   public void testParallelAsyncEventQueueHA_Scenario2() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
-    vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
 
     LogWriterUtils.getLogWriter().info("Created the cache");
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithListener2( "ln", true, 100, 5, false, null ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithListener2( "ln", true, 100, 5, false, null ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithListener2( "ln", true, 100, 5, false, null ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithListener2( "ln", true, 100, 5, false, null ));
 
     LogWriterUtils.getLogWriter().info("Created the AsyncEventQueue");
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.createPRWithRedundantCopyWithAsyncEventQueue(
+    vm1.invoke(() -> AsyncEventQueueTestBase.createPRWithRedundantCopyWithAsyncEventQueue(
             getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createPRWithRedundantCopyWithAsyncEventQueue(
+    vm2.invoke(() -> AsyncEventQueueTestBase.createPRWithRedundantCopyWithAsyncEventQueue(
             getTestMethodName() + "_PR", "ln", isOffHeap() ));
 
     LogWriterUtils.getLogWriter().info("Created PR with AsyncEventQueue");
 
-    vm4
+    vm1
         .invoke(pauseAsyncEventQueueRunnable());
-    vm5
+    vm2
         .invoke(pauseAsyncEventQueueRunnable());
     Wait.pause(1000);// pause for the batchTimeInterval to make sure the AsyncQueue
                 // is paused
 
     LogWriterUtils.getLogWriter().info("Paused the AsyncEventQueue");
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR", 80 ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR", 80 ));
 
     LogWriterUtils.getLogWriter().info("Done puts");
 
-    Set<Integer> primaryBucketsVm5 = (Set<Integer>)vm5.invoke(() -> AsyncEventQueueTestBase.getAllPrimaryBucketsOnTheNode( getTestMethodName() + "_PR" ));
+    Set<Integer> primaryBucketsvm2 = (Set<Integer>)vm2.invoke(() -> AsyncEventQueueTestBase.getAllPrimaryBucketsOnTheNode( getTestMethodName() + "_PR" ));
 
-    LogWriterUtils.getLogWriter().info("Primary buckets on vm5: " + primaryBucketsVm5);
-    // ---------------------------- Kill vm5 --------------------------
-    vm5.invoke(() -> AsyncEventQueueTestBase.killSender());
+    LogWriterUtils.getLogWriter().info("Primary buckets on vm2: " + primaryBucketsvm2);
+    // ---------------------------- Kill vm2 --------------------------
+    vm2.invoke(() -> AsyncEventQueueTestBase.killSender());
     // ----------------------------------------------------------------
 
-    // ---------------------------- start vm6 --------------------------
-    vm6.invoke(createCacheRunnable(lnPort));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithListener2( "ln", true, 100, 5, false, null ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createPRWithRedundantCopyWithAsyncEventQueue(
+    // ---------------------------- start vm3 --------------------------
+    vm3.invoke(createCacheRunnable(lnPort));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithListener2( "ln", true, 100, 5, false, null ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createPRWithRedundantCopyWithAsyncEventQueue(
             getTestMethodName() + "_PR", "ln", isOffHeap() ));
 
     // ------------------------------------------------------------------
 
     Wait.pause(1000);// give some time for rebalancing to happen
-    Set<Integer> primaryBucketsVm6 = (Set<Integer>)vm6.invoke(() -> AsyncEventQueueTestBase.getAllPrimaryBucketsOnTheNode( getTestMethodName() + "_PR" ));
+    Set<Integer> primaryBucketsvm3 = (Set<Integer>)vm3.invoke(() -> AsyncEventQueueTestBase.getAllPrimaryBucketsOnTheNode( getTestMethodName() + "_PR" ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
 
-    vm6.invoke(() -> AsyncEventQueueTestBase.verifyAsyncEventListenerForPossibleDuplicates( "ln",
-            primaryBucketsVm6, 5 ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.verifyAsyncEventListenerForPossibleDuplicates( "ln",
+            primaryBucketsvm3, 5 ));
   }
 
   /**
-   * Test case to test possibleDuplicates. vm4 & vm5 are hosting the PR. vm6 is
+   * Test case to test possibleDuplicates. vm1 & vm2 are hosting the PR. vm3 is
    * brought up and rebalancing is triggered so the buckets get balanced among
-   * vm4, vm5 & vm6.
+   * vm1, vm2 & vm3.
    */
   @Ignore("Depends on hydra code. See bug ")
   public void testParallelAsyncEventQueueHA_Scenario3() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
-    vm4.invoke(createCacheRunnable(lnPort));
-    vm5.invoke(createCacheRunnable(lnPort));
+    vm1.invoke(createCacheRunnable(lnPort));
+    vm2.invoke(createCacheRunnable(lnPort));
 
     LogWriterUtils.getLogWriter().info("Created the cache");
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithListener2( "ln", true, 100, 5, false, null ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithListener2( "ln", true, 100, 5, false, null ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithListener2( "ln", true, 100, 5, false, null ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithListener2( "ln", true, 100, 5, false, null ));
 
     LogWriterUtils.getLogWriter().info("Created the AsyncEventQueue");
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.createPRWithRedundantCopyWithAsyncEventQueue(
+    vm1.invoke(() -> AsyncEventQueueTestBase.createPRWithRedundantCopyWithAsyncEventQueue(
             getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createPRWithRedundantCopyWithAsyncEventQueue(
+    vm2.invoke(() -> AsyncEventQueueTestBase.createPRWithRedundantCopyWithAsyncEventQueue(
             getTestMethodName() + "_PR", "ln", isOffHeap() ));
 
     LogWriterUtils.getLogWriter().info("Created PR with AsyncEventQueue");
 
-    vm4
+    vm1
         .invoke(pauseAsyncEventQueueRunnable());
-    vm5
+    vm2
         .invoke(pauseAsyncEventQueueRunnable());
     Wait.pause(1000);// pause for the batchTimeInterval to make sure the AsyncQueue
                 // is paused
 
     LogWriterUtils.getLogWriter().info("Paused the AsyncEventQueue");
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR", 80 ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR", 80 ));
 
     LogWriterUtils.getLogWriter().info("Done puts");
 
-    // ---------------------------- start vm6 --------------------------
-    vm6.invoke(createCacheRunnable(lnPort));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithListener2( "ln", true, 100, 5, false, null ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createPRWithRedundantCopyWithAsyncEventQueue(
+    // ---------------------------- start vm3 --------------------------
+    vm3.invoke(createCacheRunnable(lnPort));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueueWithListener2( "ln", true, 100, 5, false, null ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createPRWithRedundantCopyWithAsyncEventQueue(
             getTestMethodName() + "_PR", "ln", isOffHeap() ));
 
     // ------------------------------------------------------------------
-    vm4.invoke(() -> AsyncEventQueueTestBase.doRebalance());
+    vm1.invoke(() -> AsyncEventQueueTestBase.doRebalance());
 
-    Set<Integer> primaryBucketsVm6 = (Set<Integer>)vm6.invoke(() -> AsyncEventQueueTestBase.getAllPrimaryBucketsOnTheNode( getTestMethodName() + "_PR" ));
-    LogWriterUtils.getLogWriter().info("Primary buckets on vm6: " + primaryBucketsVm6);
-    vm4.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
+    Set<Integer> primaryBucketsvm3 = (Set<Integer>)vm3.invoke(() -> AsyncEventQueueTestBase.getAllPrimaryBucketsOnTheNode( getTestMethodName() + "_PR" ));
+    LogWriterUtils.getLogWriter().info("Primary buckets on vm3: " + primaryBucketsvm3);
+    vm1.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
 
-    vm6.invoke(() -> AsyncEventQueueTestBase.verifyAsyncEventListenerForPossibleDuplicates( "ln",
-            primaryBucketsVm6, 5 ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.verifyAsyncEventListenerForPossibleDuplicates( "ln",
+            primaryBucketsvm3, 5 ));
   }
   
   /**

--- a/geode-core/src/test/java/com/gemstone/gemfire/internal/cache/wan/asyncqueue/AsyncEventQueueStatsDUnitTest.java
+++ b/geode-core/src/test/java/com/gemstone/gemfire/internal/cache/wan/asyncqueue/AsyncEventQueueStatsDUnitTest.java
@@ -37,37 +37,37 @@ public class AsyncEventQueueStatsDUnitTest extends AsyncEventQueueTestBase {
   public void testReplicatedSerialPropagation() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        false, 100, 100, false, false, null, false ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        false, 100, 100, false, false, null, false ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+        false, 100, 100, false, false, null, false ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
         false, 100, 100, false, false, null, false ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        false, 100, 100, false, false, null, false ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        false, 100, 100, false, false, null, false ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
-        false, 100, 100, false, false, null, false ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
         1000 ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 1000 ));// primary sender
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 1000 ));// primary sender
     Wait.pause(2000);//give some time for system to become stable
     
-    vm4.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueStats(
+    vm1.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueStats(
         "ln", 0, 1000, 1000, 1000 ));
-    vm4.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueBatchStats( "ln", 10 ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueStats(
+    vm1.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueBatchStats( "ln", 10 ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueStats(
         "ln", 0, 1000, 0, 0 ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueBatchStats( "ln", 0 ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueBatchStats( "ln", 0 ));
   }
   
   /**
@@ -76,53 +76,53 @@ public class AsyncEventQueueStatsDUnitTest extends AsyncEventQueueTestBase {
   public void testAsyncStatsTwoListeners() throws Exception {
     Integer lnPort = createFirstLocatorWithDSId(1);
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createCache(lnPort ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createCache(lnPort ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createCache(lnPort ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createCache(lnPort ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createCache(lnPort ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createCache(lnPort ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createCache(lnPort ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln1",
+      false, 100, 100, false, false, null, false ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln1",
+      false, 100, 100, false, false, null, false ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln1",
+      false, 100, 100, false, false, null, false ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln1",
       false, 100, 100, false, false, null, false ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln1",
-      false, 100, 100, false, false, null, false ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln1",
-      false, 100, 100, false, false, null, false ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln1",
-      false, 100, 100, false, false, null, false ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln2",
+      false, 100, 100, false, false, null, false ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln2",
+      false, 100, 100, false, false, null, false ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln2",
+      false, 100, 100, false, false, null, false ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln2",
       false, 100, 100, false, false, null, false ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln2",
-      false, 100, 100, false, false, null, false ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln2",
-      false, 100, 100, false, false, null, false ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln2",
-      false, 100, 100, false, false, null, false ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln1,ln2", isOffHeap() ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln1,ln2", isOffHeap() ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln1,ln2", isOffHeap() ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln1,ln2", isOffHeap() ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln1,ln2", isOffHeap() ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln1,ln2", isOffHeap() ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln1,ln2", isOffHeap() ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
         1000 ));
     
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln1", 1000 ));
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln2", 1000 ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln1", 1000 ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln2", 1000 ));
     Wait.pause(2000);//give some time for system to become stable
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueStats(
+    vm1.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueStats(
         "ln1", 0, 1000, 1000, 1000 ));
-    vm4.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueBatchStats( "ln1", 10 ));
-    vm4.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueStats(
+    vm1.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueBatchStats( "ln1", 10 ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueStats(
         "ln2", 0, 1000, 1000, 1000 ));
-    vm4.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueBatchStats( "ln2", 10 ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueStats(
+    vm1.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueBatchStats( "ln2", 10 ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueStats(
         "ln1", 0, 1000, 0, 0 ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueBatchStats( "ln1", 0 ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueStats(
+    vm2.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueBatchStats( "ln1", 0 ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueStats(
         "ln2", 0, 1000, 0, 0 ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueBatchStats( "ln2", 0 ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueBatchStats( "ln2", 0 ));
   }
   
   /**
@@ -131,28 +131,28 @@ public class AsyncEventQueueStatsDUnitTest extends AsyncEventQueueTestBase {
   public void testReplicatedSerialPropagationHA() throws Exception {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createCache(lnPort ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createCache(lnPort ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createCache(lnPort ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createCache(lnPort ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createCache(lnPort ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createCache(lnPort ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createCache(lnPort ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
       false, 100, 100, false, false, null, false ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+    vm2.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
       false, 100, 100, false, false, null, false ));
     
+    vm1.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue(
+        getTestMethodName() + "_RR", "ln", isOffHeap() ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue(
+        getTestMethodName() + "_RR", "ln", isOffHeap() ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue(
+        getTestMethodName() + "_RR", "ln", isOffHeap() ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue(
         getTestMethodName() + "_RR", "ln", isOffHeap() ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue(
-        getTestMethodName() + "_RR", "ln", isOffHeap() ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue(
-        getTestMethodName() + "_RR", "ln", isOffHeap() ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue(
-        getTestMethodName() + "_RR", "ln", isOffHeap() ));
     
-    AsyncInvocation inv1 = vm5.invokeAsync(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR", 10000 ));
+    AsyncInvocation inv1 = vm2.invokeAsync(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR", 10000 ));
     Wait.pause(2000);
-    AsyncInvocation inv2 = vm4.invokeAsync(() -> AsyncEventQueueTestBase.killAsyncEventQueue( "ln" ));
+    AsyncInvocation inv2 = vm1.invokeAsync(() -> AsyncEventQueueTestBase.killAsyncEventQueue( "ln" ));
     Boolean isKilled = Boolean.FALSE;
     try {
       isKilled = (Boolean)inv2.getResult();
@@ -162,13 +162,13 @@ public class AsyncEventQueueStatsDUnitTest extends AsyncEventQueueTestBase {
     }
     AsyncInvocation inv3 = null; 
     if(!isKilled){
-      inv3 = vm5.invokeAsync(() -> AsyncEventQueueTestBase.killSender( "ln" ));
+      inv3 = vm2.invokeAsync(() -> AsyncEventQueueTestBase.killSender( "ln" ));
       inv3.join();
     }
     inv1.join();
     inv2.join();
     Wait.pause(2000);//give some time for system to become stable
-    vm5.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueStats_Failover("ln", 10000));
+    vm2.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueStats_Failover("ln", 10000));
   }
 
   /**
@@ -177,52 +177,52 @@ public class AsyncEventQueueStatsDUnitTest extends AsyncEventQueueTestBase {
   public void testReplicatedSerialPropagationUNPorcessedEvents() throws Exception {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
       false, 100, 100, false, false, null, false ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+    vm2.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
       false, 100, 100, false, false, null, false ));
 
     //create one RR (RR_1) on local site
+    vm1.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue(
+        getTestMethodName() + "_RR_1", "ln", isOffHeap() ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue(
+        getTestMethodName() + "_RR_1", "ln", isOffHeap() ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue(
+        getTestMethodName() + "_RR_1", "ln", isOffHeap() ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue(
-        getTestMethodName() + "_RR_1", "ln", isOffHeap() ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue(
-        getTestMethodName() + "_RR_1", "ln", isOffHeap() ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue(
-        getTestMethodName() + "_RR_1", "ln", isOffHeap() ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue(
         getTestMethodName() + "_RR_1", "ln", isOffHeap() ));
 
     //create another RR (RR_2) on local site
+    vm1.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue(
+        getTestMethodName() + "_RR_2", "ln", isOffHeap() ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue(
+        getTestMethodName() + "_RR_2", "ln", isOffHeap() ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue(
+        getTestMethodName() + "_RR_2", "ln", isOffHeap() ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue(
-        getTestMethodName() + "_RR_2", "ln", isOffHeap() ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue(
-        getTestMethodName() + "_RR_2", "ln", isOffHeap() ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue(
-        getTestMethodName() + "_RR_2", "ln", isOffHeap() ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue(
         getTestMethodName() + "_RR_2", "ln", isOffHeap() ));
     
     //start puts in RR_1 in another thread
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR_1", 1000 ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR_1", 1000 ));
     //do puts in RR_2 in main thread
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPutsFrom( getTestMethodName() + "_RR_2", 1000, 1500 ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPutsFrom( getTestMethodName() + "_RR_2", 1000, 1500 ));
     
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 1500 ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 1500 ));
         
     Wait.pause(2000);//give some time for system to become stable
-    vm4.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueStats("ln",
+    vm1.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueStats("ln",
       0, 1500, 1500, 1500));
-    vm4.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueUnprocessedStats("ln", 0));
+    vm1.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueUnprocessedStats("ln", 0));
     
     
-    vm5.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueStats("ln",
+    vm2.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueStats("ln",
       0, 1500, 0, 0));
-    vm5.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueUnprocessedStats("ln", 1500));
+    vm2.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueUnprocessedStats("ln", 1500));
   }
   
   /**
@@ -231,20 +231,20 @@ public class AsyncEventQueueStatsDUnitTest extends AsyncEventQueueTestBase {
   public void testSerialPropagationConflation() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
         false, 100, 100, true, false, null, false ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
     
-    vm4
+    vm1
         .invoke(() -> AsyncEventQueueTestBase.pauseAsyncEventQueue( "ln" ));
     //pause at least for the batchTimeInterval to make sure that the AsyncEventQueue is actually paused
     Wait.pause(2000);
@@ -255,8 +255,8 @@ public class AsyncEventQueueStatsDUnitTest extends AsyncEventQueueTestBase {
       keyValues.put(i, i);
     }
     
-    vm4.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue( getTestMethodName() + "_RR", keyValues ));
-    vm4.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueSize( "ln", keyValues.size() ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue( getTestMethodName() + "_RR", keyValues ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueSize( "ln", keyValues.size() ));
     
     for(int i=0;i<500;i++) {
       updateKeyValues.put(i, i+"_updated");
@@ -264,22 +264,22 @@ public class AsyncEventQueueStatsDUnitTest extends AsyncEventQueueTestBase {
     
     // Put the update events and check the queue size.
     // There should be no conflation with the previous create events.
-    vm4.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue( getTestMethodName() + "_RR", updateKeyValues ));    
-    vm4.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueSize( "ln", keyValues.size() + updateKeyValues.size() ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue( getTestMethodName() + "_RR", updateKeyValues ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueSize( "ln", keyValues.size() + updateKeyValues.size() ));
     
     // Put the update events again and check the queue size.
     // There should be conflation with the previous update events.
-    vm4.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue( getTestMethodName() + "_RR", updateKeyValues ));    
-    vm4.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueSize( "ln", keyValues.size() + updateKeyValues.size() ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.putGivenKeyValue( getTestMethodName() + "_RR", updateKeyValues ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueSize( "ln", keyValues.size() + updateKeyValues.size() ));
     
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));
   
-    vm4.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 1000 ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.resumeAsyncEventQueue( "ln" ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 1000 ));
     
     Wait.pause(2000);// give some time for system to become stable
-    vm4.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueStats(
+    vm1.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueStats(
         "ln", 0, 2000, 2000, 1000 ));
-    vm4.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueConflatedStats( "ln", 500 ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.checkAsyncEventQueueConflatedStats( "ln", 500 ));
   }
 }

--- a/geode-core/src/test/java/com/gemstone/gemfire/internal/cache/wan/concurrent/ConcurrentAsyncEventQueueDUnitTest.java
+++ b/geode-core/src/test/java/com/gemstone/gemfire/internal/cache/wan/concurrent/ConcurrentAsyncEventQueueDUnitTest.java
@@ -36,35 +36,35 @@ public class ConcurrentAsyncEventQueueDUnitTest extends AsyncEventQueueTestBase 
   public void testConcurrentSerialAsyncEventQueueAttributes() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+    vm1.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
         false, 100, 150, true, true, "testDS", true, 5, OrderPolicy.THREAD ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateConcurrentAsyncEventQueueAttributes( "ln", 100, 150, AsyncEventQueueFactoryImpl.DEFAULT_BATCH_TIME_INTERVAL, true, "testDS", true, true, 5, OrderPolicy.THREAD ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateConcurrentAsyncEventQueueAttributes( "ln", 100, 150, AsyncEventQueueFactoryImpl.DEFAULT_BATCH_TIME_INTERVAL, true, "testDS", true, true, 5, OrderPolicy.THREAD ));
   }
   
  
   public void testConcurrentParallelAsyncEventQueueAttributesOrderPolicyKey() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+    vm1.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
         true, 100, 150, true, true, "testDS", true, 5, OrderPolicy.KEY ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateConcurrentAsyncEventQueueAttributes( "ln", 100, 150, AsyncEventQueueFactoryImpl.DEFAULT_BATCH_TIME_INTERVAL, true, "testDS", true, true, 5, OrderPolicy.KEY ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateConcurrentAsyncEventQueueAttributes( "ln", 100, 150, AsyncEventQueueFactoryImpl.DEFAULT_BATCH_TIME_INTERVAL, true, "testDS", true, true, 5, OrderPolicy.KEY ));
   }
 
   public void testConcurrentParallelAsyncEventQueueAttributesOrderPolicyPartition() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+    vm1.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
         true, 100, 150, true, true, "testDS", true, 5, OrderPolicy.PARTITION ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateConcurrentAsyncEventQueueAttributes( "ln", 100, 150, AsyncEventQueueFactoryImpl.DEFAULT_BATCH_TIME_INTERVAL, true, "testDS", true, true, 5, OrderPolicy.PARTITION ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateConcurrentAsyncEventQueueAttributes( "ln", 100, 150, AsyncEventQueueFactoryImpl.DEFAULT_BATCH_TIME_INTERVAL, true, "testDS", true, true, 5, OrderPolicy.PARTITION ));
   }
   
   /**
@@ -79,37 +79,37 @@ public class ConcurrentAsyncEventQueueDUnitTest extends AsyncEventQueueTestBase 
   public void testReplicatedSerialAsyncEventQueueWithMultipleDispatcherThreadsOrderPolicyKey() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+        false, 100, 10, true, false, null, false, 3, OrderPolicy.KEY ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+        false, 100, 10, true, false, null, false, 3, OrderPolicy.KEY ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+        false, 100, 10, true, false, null, false, 3, OrderPolicy.KEY ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
         false, 100, 10, true, false, null, false, 3, OrderPolicy.KEY ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
-        false, 100, 10, true, false, null, false, 3, OrderPolicy.KEY ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
-        false, 100, 10, true, false, null, false, 3, OrderPolicy.KEY ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
-        false, 100, 10, true, false, null, false, 3, OrderPolicy.KEY ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
         100 ));
     
+    vm1.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
     vm4.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
     
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 100 ));// primary sender
-    vm5.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
-    vm6.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
-    vm7.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 100 ));// primary sender
+    vm2.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm3.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
   }
   
   /**
@@ -124,30 +124,30 @@ public class ConcurrentAsyncEventQueueDUnitTest extends AsyncEventQueueTestBase 
   public void testReplicatedSerialAsyncEventQueueWithMultipleDispatcherThreadsOrderPolicyThread() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+        false, 100, 10, true, false, null, false, 3, OrderPolicy.THREAD ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+        false, 100, 10, true, false, null, false, 3, OrderPolicy.THREAD ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+        false, 100, 10, true, false, null, false, 3, OrderPolicy.THREAD ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
         false, 100, 10, true, false, null, false, 3, OrderPolicy.THREAD ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
-        false, 100, 10, true, false, null, false, 3, OrderPolicy.THREAD ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
-        false, 100, 10, true, false, null, false, 3, OrderPolicy.THREAD ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
-        false, 100, 10, true, false, null, false, 3, OrderPolicy.THREAD ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createReplicatedRegionWithAsyncEventQueue( getTestMethodName() + "_RR", "ln", isOffHeap() ));
 
-    AsyncInvocation inv1 = vm4.invokeAsync(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
+    AsyncInvocation inv1 = vm1.invokeAsync(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_RR",
         50 ));
-    AsyncInvocation inv2 = vm4.invokeAsync(() -> AsyncEventQueueTestBase.doNextPuts( getTestMethodName() + "_RR",
+    AsyncInvocation inv2 = vm1.invokeAsync(() -> AsyncEventQueueTestBase.doNextPuts( getTestMethodName() + "_RR",
       50, 100 ));
-    AsyncInvocation inv3 = vm4.invokeAsync(() -> AsyncEventQueueTestBase.doNextPuts( getTestMethodName() + "_RR",
+    AsyncInvocation inv3 = vm1.invokeAsync(() -> AsyncEventQueueTestBase.doNextPuts( getTestMethodName() + "_RR",
       100, 150 ));
     
     try {
@@ -160,15 +160,15 @@ public class ConcurrentAsyncEventQueueDUnitTest extends AsyncEventQueueTestBase 
           ie);
     }
     
+    vm1.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
     vm4.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 150 ));// primary sender
-    vm5.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
-    vm6.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
-    vm7.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm1.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 150 ));// primary sender
+    vm2.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm3.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
+    vm4.invoke(() -> AsyncEventQueueTestBase.validateAsyncEventListener( "ln", 0 ));// secondary
   }
   
   /**
@@ -183,39 +183,39 @@ public class ConcurrentAsyncEventQueueDUnitTest extends AsyncEventQueueTestBase 
   public void testPartitionedParallelAsyncEventQueueWithMultipleDispatcherThreadsOrderPolicyKey() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+        true, 100, 10, true, false, null, false, 3, OrderPolicy.KEY ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+        true, 100, 10, true, false, null, false, 3, OrderPolicy.KEY ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
+        true, 100, 10, true, false, null, false, 3, OrderPolicy.KEY ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
         true, 100, 10, true, false, null, false, 3, OrderPolicy.KEY ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
-        true, 100, 10, true, false, null, false, 3, OrderPolicy.KEY ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
-        true, 100, 10, true, false, null, false, 3, OrderPolicy.KEY ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln",
-        true, 100, 10, true, false, null, false, 3, OrderPolicy.KEY ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR",
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR",
         100 ));
     
+    vm1.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
     vm4.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
   
+    int vm1size = (Integer)vm1.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
+    int vm2size = (Integer)vm2.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
+    int vm3size = (Integer)vm3.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
     int vm4size = (Integer)vm4.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
-    int vm5size = (Integer)vm5.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
-    int vm6size = (Integer)vm6.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
-    int vm7size = (Integer)vm7.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln"));
   
-    assertEquals(vm4size + vm5size + vm6size + vm7size, 100);
+    assertEquals(vm1size + vm2size + vm3size + vm4size, 100);
   
   }
   
@@ -232,38 +232,38 @@ public class ConcurrentAsyncEventQueueDUnitTest extends AsyncEventQueueTestBase 
   public void testPartitionedParallelAsyncEventQueueWithMultipleDispatcherThreadsOrderPolicyPartition() {
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln", true, 100, 10, true, false, null, false, 3,
+            OrderPolicy.PARTITION ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln", true, 100, 10, true, false, null, false, 3,
+            OrderPolicy.PARTITION ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln", true, 100, 10, true, false, null, false, 3,
+            OrderPolicy.PARTITION ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln", true, 100, 10, true, false, null, false, 3,
             OrderPolicy.PARTITION ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln", true, 100, 10, true, false, null, false, 3,
-            OrderPolicy.PARTITION ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln", true, 100, 10, true, false, null, false, 3,
-            OrderPolicy.PARTITION ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createConcurrentAsyncEventQueue( "ln", true, 100, 10, true, false, null, false, 3,
-            OrderPolicy.PARTITION ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
     vm4.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR", "ln", isOffHeap() ));
 
-    vm4.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR",
+    vm1.invoke(() -> AsyncEventQueueTestBase.doPuts( getTestMethodName() + "_PR",
         100 ));
 
+    vm1.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm2.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
+    vm3.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
     vm4.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm5.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm6.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
-    vm7.invoke(() -> AsyncEventQueueTestBase.waitForAsyncQueueToGetEmpty( "ln" ));
 
+    int vm1size = (Integer)vm1.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln" ));
+    int vm2size = (Integer)vm2.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln" ));
+    int vm3size = (Integer)vm3.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln" ));
     int vm4size = (Integer)vm4.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln" ));
-    int vm5size = (Integer)vm5.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln" ));
-    int vm6size = (Integer)vm6.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln" ));
-    int vm7size = (Integer)vm7.invoke(() -> AsyncEventQueueTestBase.getAsyncEventListenerMapSize( "ln" ));
 
-    assertEquals(100, vm4size + vm5size + vm6size + vm7size);
+    assertEquals(100, vm1size + vm2size + vm3size + vm4size);
   }
 }

--- a/geode-core/src/test/java/com/gemstone/gemfire/internal/cache/wan/misc/CommonParallelAsyncEventQueueDUnitTest.java
+++ b/geode-core/src/test/java/com/gemstone/gemfire/internal/cache/wan/misc/CommonParallelAsyncEventQueueDUnitTest.java
@@ -34,12 +34,12 @@ public class CommonParallelAsyncEventQueueDUnitTest extends AsyncEventQueueTestB
   public void testSameSenderWithNonColocatedRegions() throws Exception {
     IgnoredException.addIgnoredException("cannot have the same parallel async");
     Integer lnPort = (Integer)vm0.invoke(() -> AsyncEventQueueTestBase.createFirstLocatorWithDSId( 1 ));
-    vm4.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
-    vm4.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
+    vm1.invoke(() -> AsyncEventQueueTestBase.createCache( lnPort ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.createAsyncEventQueue( "ln",
       true, 100, 100, false, false, null, false ));
-    vm4.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR1", "ln", isOffHeap()  ));
+    vm1.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR1", "ln", isOffHeap()  ));
     try {
-      vm4.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR2", "ln", isOffHeap()  ));
+      vm1.invoke(() -> AsyncEventQueueTestBase.createPartitionedRegionWithAsyncEventQueue( getTestMethodName() + "_PR2", "ln", isOffHeap()  ));
       fail("Expected IllegateStateException : cannot have the same parallel gateway sender");
     }
     catch (Exception e) {


### PR DESCRIPTION
* Refactored all the test cases to use lower numbered VMs
* VM5-VM7 were unused hence removed from AsyncEventQueueTestBase