### PR TITLE
GEODE-1028: Fix broken link on website's Releases page

### DIFF
--- a/geode-site/website/content/releases/index.html
+++ b/geode-site/website/content/releases/index.html
@@ -173,7 +173,7 @@ under the License. -->
     			<p>
 					Alternatively, you can verify the MD5 signature on the files. A Unix program called md5 or md5sum is included in many Unix distributions. It is also available as part of <a href="http://www.gnu.org/software/textutils/textutils.html">GNU Textutils</a>. Windows users can get binary md5 programs from <a href="http://www.fourmilab.ch/md5/">here</a>, <a href="http://www.pc-tools.net/win32/md5sums/">here</a>, or <a href="http://www.slavasoft.com/fsum/">here</a>.
 				<p>
-					If you want to build directly from the sources, please check the <a href="/docs/getting-up-and-running-locally/">Project Docs</a>.
+					If you want to build directly from source, instructions are within the User Documentation in the <a href="http://geode.docs.pivotal.io/docs/getting_started/installation/install_standalone.html">How to Install</a> subsection.
 				</p>
 			</div>
 		</div>


### PR DESCRIPTION
The new link goes directly to the page that explains how to
build from source.