### PR TITLE
Feature/geode 1256

### DIFF
--- a/geode-site/website/content/releases/index.html
+++ b/geode-site/website/content/releases/index.html
@@ -173,7 +173,7 @@ under the License. -->
     			<p>
 					Alternatively, you can verify the MD5 signature on the files. A Unix program called md5 or md5sum is included in many Unix distributions. It is also available as part of <a href="http://www.gnu.org/software/textutils/textutils.html">GNU Textutils</a>. Windows users can get binary md5 programs from <a href="http://www.fourmilab.ch/md5/">here</a>, <a href="http://www.pc-tools.net/win32/md5sums/">here</a>, or <a href="http://www.slavasoft.com/fsum/">here</a>.
 				<p>
-					If you want to build directly from the sources, please check the <a href="/docs/getting-up-and-running-locally/">Project Docs</a>.
+					If you want to build directly from source, instructions are within the User Documentation in the <a href="http://geode.docs.pivotal.io/docs/getting_started/installation/install_standalone.html">How to Install</a> subsection.
 				</p>
 			</div>
 		</div>

--- a/gradle/rat.gradle
+++ b/gradle/rat.gradle
@@ -116,6 +116,7 @@ rat {
     'geode-site/website/content/css/font-awesome.min.css',
     'geode-site/website/lib/pandoc.template',
     'geode-site/website/content/font/**',
+    'geode-site/content/**',
     // compiled logs and locks
     'geode-site/website/tmp/**',
     'geode-site/website/layouts/**',


### PR DESCRIPTION
GEODE-1256  Alter rat.gradle to exclude copies of website sources
    
    Added `geode-site/content/**` to the rat.gradle excludes list
    such that there are no longer 10 Unknown Licenses.