### PR TITLE
GEODE-1256  Alter rat.gradle to exclude copies of website sources

### DIFF
--- a/gradle/rat.gradle
+++ b/gradle/rat.gradle
@@ -117,6 +117,7 @@ rat {
     'geode-site/website/content/css/font-awesome.min.css',
     'geode-site/website/lib/pandoc.template',
     'geode-site/website/content/font/**',
+    'geode-site/content/**',
     // compiled logs and locks
     'geode-site/website/tmp/**',
     'geode-site/website/layouts/**',


### PR DESCRIPTION
  Added `geode-site/content/**` to the rat.gradle excludes list
  such that there are no longer 10 Unknown Licenses.