### PR TITLE
GEODE-1121: Reduced the memory configurations in the overflow tests.

### DIFF
--- a/geode-wan/src/test/java/com/gemstone/gemfire/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/test/java/com/gemstone/gemfire/internal/cache/wan/WANTestBase.java
@@ -854,8 +854,8 @@ public class WANTestBase extends DistributedTestCase{
     }
   }
 
-  public static void addListenerToSleepAfterCreateEvent(int milliSeconds) {
-    cache.getRegion(getTestMethodName() + "_RR_1").getAttributesMutator()
+  public static void addListenerToSleepAfterCreateEvent(int milliSeconds, final String regionName) {
+    cache.getRegion(regionName).getAttributesMutator()
       .addCacheListener(new CacheListenerAdapter<Object, Object>() {
         @Override
         public void afterCreate(final EntryEvent<Object, Object> event) {

--- a/geode-wan/src/test/java/com/gemstone/gemfire/internal/cache/wan/concurrent/ConcurrentWANPropogation_2_DUnitTest.java
+++ b/geode-wan/src/test/java/com/gemstone/gemfire/internal/cache/wan/concurrent/ConcurrentWANPropogation_2_DUnitTest.java
@@ -50,9 +50,9 @@ public class ConcurrentWANPropogation_2_DUnitTest extends WANTestBase {
 
     //keep the maxQueueMemory low enough to trigger eviction
     vm4.invoke(() -> WANTestBase.createConcurrentSender( "ln", 2,
-        false, 50, 5, false, false, null, true, 5, OrderPolicy.KEY ));
+        false, 10, 5, false, false, null, true, 5, OrderPolicy.KEY ));
     vm5.invoke(() -> WANTestBase.createConcurrentSender( "ln", 2,
-        false, 50, 5, false, false, null, true, 5, OrderPolicy.KEY ));
+        false, 10, 5, false, false, null, true, 5, OrderPolicy.KEY ));
 
     vm2.invoke(() -> WANTestBase.createReplicatedRegion(
         getTestMethodName() + "_RR", null, isOffHeap() ));
@@ -60,6 +60,8 @@ public class ConcurrentWANPropogation_2_DUnitTest extends WANTestBase {
         getTestMethodName() + "_RR", null, isOffHeap() ));
 
     startSenderInVMs("ln", vm4, vm5);
+    vm2.invoke(() -> addListenerToSleepAfterCreateEvent(1000, getTestMethodName() + "_RR"));
+    vm3.invoke(() -> addListenerToSleepAfterCreateEvent(1000, getTestMethodName() + "_RR"));
 
     vm4.invoke(() -> WANTestBase.createReplicatedRegion(
         getTestMethodName() + "_RR", "ln", isOffHeap() ));
@@ -71,12 +73,12 @@ public class ConcurrentWANPropogation_2_DUnitTest extends WANTestBase {
         getTestMethodName() + "_RR", "ln", isOffHeap() ));
 
     vm4.invoke(() -> WANTestBase.doHeavyPuts(
-        getTestMethodName() + "_RR", 150 ));
+        getTestMethodName() + "_RR", 15 ));
 
     vm2.invoke(() -> WANTestBase.validateRegionSize(
-        getTestMethodName() + "_RR", 150, 240000));
+        getTestMethodName() + "_RR", 15, 240000));
     vm3.invoke(() -> WANTestBase.validateRegionSize(
-        getTestMethodName() + "_RR", 150, 240000 ));
+        getTestMethodName() + "_RR", 15, 240000 ));
   }
 
   public void Bug46921_testSerialReplicatedWanWithPersistence() {

--- a/geode-wan/src/test/java/com/gemstone/gemfire/internal/cache/wan/serial/SerialWANPropogationDUnitTest.java
+++ b/geode-wan/src/test/java/com/gemstone/gemfire/internal/cache/wan/serial/SerialWANPropogationDUnitTest.java
@@ -785,7 +785,7 @@ public class SerialWANPropogationDUnitTest extends WANTestBase {
 
     // create one RR (RR_1) on remote site
     vm2.invoke(() -> WANTestBase.createPersistentReplicatedRegion(getTestMethodName() + "_RR_1", null, isOffHeap()));
-    vm2.invoke(() -> WANTestBase.addListenerToSleepAfterCreateEvent(2000));
+    vm2.invoke(() -> WANTestBase.addListenerToSleepAfterCreateEvent(2000, getTestMethodName() + "_RR_1"));
     // start the senders on local site
     startSenderInVMs("ln", vm4, vm5);
 
@@ -976,8 +976,8 @@ public class SerialWANPropogationDUnitTest extends WANTestBase {
 
     vm3.invoke(() -> WANTestBase.createPersistentReplicatedRegion(getTestMethodName() + "_RR_1", null, isOffHeap()));
 
-    vm2.invoke(() -> addListenerToSleepAfterCreateEvent(2000));
-    vm3.invoke(() -> addListenerToSleepAfterCreateEvent(2000));
+    vm2.invoke(() -> addListenerToSleepAfterCreateEvent(2000, getTestMethodName() + "_RR_1"));
+    vm3.invoke(() -> addListenerToSleepAfterCreateEvent(2000, getTestMethodName() + "_RR_1"));
 
     // create one RR (RR_1) on local site
     vm4.invoke(() -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR_1", "ln", isOffHeap()));

--- a/geode-wan/src/test/java/com/gemstone/gemfire/internal/cache/wan/serial/SerialWANPropogationsFeatureDUnitTest.java
+++ b/geode-wan/src/test/java/com/gemstone/gemfire/internal/cache/wan/serial/SerialWANPropogationsFeatureDUnitTest.java
@@ -38,9 +38,9 @@ public class SerialWANPropogationsFeatureDUnitTest extends WANTestBase{
     createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
 
     vm4.invoke(() -> WANTestBase.createSender( "ln", 2,
-        false, 100, 10, false, false, null, true ));
+        false, 10, 10, false, false, null, true ));
     vm5.invoke(() -> WANTestBase.createSender( "ln", 2,
-        false, 100, 10, false, false, null, true ));
+        false, 10, 10, false, false, null, true ));
 
     vm2.invoke(() -> WANTestBase.createReplicatedRegion(
         getTestMethodName() + "_RR", null, isOffHeap()  ));
@@ -48,6 +48,8 @@ public class SerialWANPropogationsFeatureDUnitTest extends WANTestBase{
         getTestMethodName() + "_RR", null, isOffHeap()  ));
 
     startSenderInVMs("ln", vm4, vm5);
+    vm2.invoke(() -> addListenerToSleepAfterCreateEvent(1000, getTestMethodName() + "_RR"));
+    vm3.invoke(() -> addListenerToSleepAfterCreateEvent(1000, getTestMethodName() + "_RR"));
 
     vm4.invoke(() -> WANTestBase.createReplicatedRegion(
         getTestMethodName() + "_RR", "ln", isOffHeap()  ));
@@ -59,12 +61,12 @@ public class SerialWANPropogationsFeatureDUnitTest extends WANTestBase{
         getTestMethodName() + "_RR", "ln", isOffHeap()  ));
 
     vm4.invoke(() -> WANTestBase.doHeavyPuts(
-        getTestMethodName() + "_RR", 120 ));
+        getTestMethodName() + "_RR", 15 ));
 
     vm2.invoke(() -> WANTestBase.validateRegionSize(
-        getTestMethodName() + "_RR", 120, 240000 ));
+        getTestMethodName() + "_RR", 15, 240000 ));
     vm3.invoke(() -> WANTestBase.validateRegionSize(
-        getTestMethodName() + "_RR", 120, 240000 ));
+        getTestMethodName() + "_RR", 15, 240000 ));
   }
 
   public void testSerialReplicatedWanWithPersistence() {


### PR DESCRIPTION
* Reduced the sender's max memory to 1MB.
* Reduced the amount of puts to 5MB.
* Introduced a listener to sleep on create event in the receiver to slow down the sender.
* Modified the addListenerToSleepOnCreate function signature to take region name as a parameter.