### PR TITLE
GEODE-1543: Change the log level from error to info

### DIFF
--- a/geode-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/com/gemstone/gemfire/internal/cache/LocalRegion.java
@@ -2452,8 +2452,9 @@ public class LocalRegion extends AbstractRegion
             indexes.add(qs.createIndex(icd.getIndexName(), icd.getIndexType(), icd.getIndexExpression(), fromClause, icd.getIndexImportString(), !isOverflowToDisk));
           }
 
-        } catch (Exception ex) {
-          logger.error("Failed to create index {} on region {} with exception: {}", icd.getIndexName(), this.getFullPath(), ex);
+        }
+        catch (Exception ex) {
+          logger.info("Failed to create index {} on region {} with exception: {}", icd.getIndexName(), this.getFullPath(), ex);
 
           // Check if the region index creation is from cache.xml, in that case throw exception.
           // Other case is when bucket regions are created dynamically, in that case ignore the exception.


### PR DESCRIPTION
* When multiple peers join the cluster conncurrently, only the first one that joins will distribute the index creation and other will try to create the index locally because of the distributed message and then log an error afterwards.
* This is an expected behaviour and hence should not be logged as error but rather as a info.