### PR TITLE
GEODE-1530: geode-examples setEnv.sh script needs to export path

### DIFF
--- a/geode-examples/replicated/scripts/setEnv.sh
+++ b/geode-examples/replicated/scripts/setEnv.sh
@@ -22,3 +22,6 @@
 ## check if gfsh script is accessible and print version
 : ${GEODE_HOME/bin/gfsh?"gfsh doesn't seem to be available. Please check $GEODE_HOME"}
 echo "Geode version: `$GEODE_HOME/bin/gfsh version`"
+
+## prefer GEODE_HOME for finding gfsh
+export PATH=$GEODE_HOME/bin:$PATH

--- a/geode-examples/replicated/scripts/stopAll.sh
+++ b/geode-examples/replicated/scripts/stopAll.sh
@@ -19,4 +19,6 @@ set -e
 
 cd `dirname $0`
 
+. ./setEnv.sh
+
 gfsh -e "connect" -e "shutdown --include-locators=true"


### PR DESCRIPTION
Without an export of the path, using the GEODE_HOME env variable,
the scripts/startAll.sh script will pick up the first gfsh in the
path that it finds.

Also updated the scripts/stopAll.sh script to run the setEnv.sh
script, so that stopAll.sh uses the correct gfsh.