### PR TITLE
GEODE-1525: Examples README.md should set env variable

### DIFF
--- a/geode-examples/README.md
+++ b/geode-examples/README.md
@@ -1,68 +1,70 @@
 # Apache Geode examples
 
-This is the home of Apache Geode examples that are bundled with the project. Contributions<sup>[2]</sup> and corrections are as usual welcome and if you have any suggestions come talk to us at [dev@geode.incubator.apache.org](mailto:dev@geode.incubator.apache.org) or just submit a [pull request](https://github.com/apache/incubator-geode/pull/new/develop).
+This is the home of Apache Geode examples that are bundled with the project. Contributions<sup>[2]</sup> and corrections are welcome. Please talk to us about your suggestions at [dev@geode.incubator.apache.org](mailto:dev@geode.incubator.apache.org) or submit a [pull request](https://github.com/apache/incubator-geode/pull/new/develop).
 
 ## Example requirements
 
 All examples:
- * Needs to be testable. (unit tests, integration tests or what's applicable) - Tests will ran through project CI.
- * Should be `Gradle` projects or part of existing ones. <sup>There could be a few exceptions here, but community should have consensus to accept</sup>
- * Have to follow code format & style from Apache Geode <sup>[1]</sup> guidelines.
- * Should contain a `README.md` file with step-by-step instruction on how to setup and run. (Diagrams give extra credits).
- * Donations need to be licensed through ASL 2.0 and contributors need to file an ICLA<sup>[3]</sup>
+
+*  Need to be testable. Use unit tests, integration tests or whatever is applicable. Tests will run through the project's CI.
+*  Should be `Gradle` projects or part of existing ones. There may be exceptions here, but the community should have a consensus to accept.
+*  Have to follow code format & style from Apache Geode <sup>[1]</sup> guidelines.
+*  Should contain a `README.md` file with step-by-step instruction on how to set up and run the example. *Diagrams give you extra credit.*
+*  Donations need to be licensed through ASL 2.0 and contributors need to file an ICLA<sup>[3]</sup>.
 
 ## Structure
 
-### Quick start & Installation
+### Installation and a Tutorial for Beginners
 
-  * [How to Install](http://geode.docs.pivotal.io/docs/getting_started/installation/install_standalone.html)
-  * [Apache Geode in 15 minutes or Less](http://geode.docs.pivotal.io/docs/getting_started/15_minute_quickstart_gfsh.html)
+*  [How to Install](http://geode.docs.pivotal.io/docs/getting_started/installation/install_standalone.html)
+*  Set a `GEODE_HOME` environment variable to point to the `bin` directory of the installation. For those that have built from source, this will be the `geode-assembly/build/install/apache-geode` directory.
+*  If desired run the tutorial: [Apache Geode in 15 minutes or Less](http://geode.docs.pivotal.io/docs/getting_started/15_minute_quickstart_gfsh.html)
 
 ### Basics
 
-  * [Replicated Region]()
-  * Partitioned Region
-  * Persistence
-  * OQL (Querying)
+*  [Replicated Region]()
+*  Partitioned Region
+*  Persistence
+*  OQL (Querying)
 
 ### Intermediate
 
-  * PDX & Serialization
-  * Functions
-  * CacheLoader & CacheWriter
-  * Listeners
-  * Async Event Queues
-  * Continuous Querying
-  * Transactions
-  * Eviction
-  * Expiration
-  * Overflow
-  * Security
-  * Off-heap
+*  PDX & Serialization
+*  Functions
+*  CacheLoader & CacheWriter
+*  Listeners
+*  Async Event Queues
+*  Continuous Querying
+*  Transactions
+*  Eviction
+*  Expiration
+*  Overflow
+*  Security
+*  Off-heap
 
 ### Advanced
 
-  * WAN Gateway
-  * Durable subscriptions
-  * Delta propagation
-  * Network partition detection
-  * D-lock
-  * Compression
-  * Resource manager
-  * PDX Advanced
+*  WAN Gateway
+*  Durable subscriptions
+*  Delta propagation
+*  Network partition detection
+*  D-lock
+*  Compression
+*  Resource manager
+*  PDX Advanced
 
 ### Use cases & integrations
 
- This section should have self contained little projects that illustrate a use case or integration with some other projects.
+This section has self-contained little projects that illustrate a use case or an integration with other projects.
 
-  * SpringBoot Application
-  * HTTP Session replication
-  * Redis
-  * Memcached
-  * Spark Connector
+*  SpringBoot Application
+*  HTTP Session replication
+*  Redis
+*  Memcached
+*  Spark Connector
 
 ## References
 
-- [1] - https://cwiki.apache.org/confluence/display/GEODE/Criteria+for+Code+Submissions
-- [2] - https://cwiki.apache.org/confluence/display/GEODE/How+to+Contribute
-- [3] - http://www.apache.org/licenses/#clas
+- [1]  [https://cwiki.apache.org/confluence/display/GEODE/Criteria+for+Code+Submissions](https://cwiki.apache.org/confluence/display/GEODE/Criteria+for+Code+Submissions)
+- [2]  [https://cwiki.apache.org/confluence/display/GEODE/How+to+Contribute](https://cwiki.apache.org/confluence/display/GEODE/How+to+Contribute)
+- [3]  [http://www.apache.org/licenses/#clas](http://www.apache.org/licenses/#clas)


### PR DESCRIPTION
GEODE-1523: Improve examples README.md markdown

This PR fixes addresses both GEODE-1525 and GEODE-1523, as they
both change the contents of the same file: geode-examples/README.md.

- Each example will likely use a scripts/setEnv.sh script to set
  the path to gfsh. The script depends on a GEODE_HOME environment
  variable, so this top level of instructions for setting up
  the examples now tells the user to set a GEODE_HOME env variable
  directly after the installation.

- Implement a more strict markdown that displays correctly for a
  wide variety of markdown implementations.

- Put in links for the 3 references.

- Improve the prose.