### PR TITLE
GEODE-11: Index and AEQ stored in the same disk store as the region

### DIFF
--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/LuceneIndexForPartitionedRegion.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/LuceneIndexForPartitionedRegion.java
@@ -77,13 +77,13 @@ public class LuceneIndexForPartitionedRegion extends LuceneIndexImpl {
       final String fileRegionName = createFileRegionName();
       PartitionAttributes partitionAttributes = dataRegion.getPartitionAttributes();
       if (!fileRegionExists(fileRegionName)) {
-        fileRegion = createFileRegion(regionShortCut, fileRegionName, partitionAttributes);
+        fileRegion = createFileRegion(regionShortCut, fileRegionName, partitionAttributes, ra);
       }
 
       // create PR chunkRegion, but not to create its buckets for now
       final String chunkRegionName = createChunkRegionName();
       if (!chunkRegionExists(chunkRegionName)) {
-        chunkRegion = createChunkRegion(regionShortCut, fileRegionName, partitionAttributes, chunkRegionName);
+        chunkRegion = createChunkRegion(regionShortCut, fileRegionName, partitionAttributes, chunkRegionName, ra);
       }
       fileSystemStats.setFileSupplier(() -> (int) getFileRegion().getLocalSize());
       fileSystemStats.setChunkSupplier(() -> (int) getChunkRegion().getLocalSize());
@@ -123,6 +123,7 @@ public class LuceneIndexForPartitionedRegion extends LuceneIndexImpl {
     if(dataRegion.getAttributes().getDataPolicy().withPersistence()) {
       factory.setPersistent(true);
     }
+    factory.setDiskStoreName(dataRegion.getAttributes().getDiskStoreName());
     factory.setDiskSynchronous(dataRegion.getAttributes().isDiskSynchronous());
     factory.setForwardExpirationDestroy(true);
     return factory;
@@ -145,8 +146,9 @@ public class LuceneIndexForPartitionedRegion extends LuceneIndexImpl {
 
   Region createFileRegion(final RegionShortcut regionShortCut,
                                 final String fileRegionName,
-                                final PartitionAttributes partitionAttributes) {
-    return createRegion(fileRegionName, regionShortCut, this.regionPath, partitionAttributes);
+                                final PartitionAttributes partitionAttributes,
+                                final RegionAttributes regionAttributes) {
+    return createRegion(fileRegionName, regionShortCut, this.regionPath, partitionAttributes, regionAttributes);
   }
 
   public String createFileRegionName() {
@@ -159,8 +161,8 @@ public class LuceneIndexForPartitionedRegion extends LuceneIndexImpl {
 
   Region<ChunkKey, byte[]> createChunkRegion(final RegionShortcut regionShortCut,
                            final String fileRegionName,
-                           final PartitionAttributes partitionAttributes, final String chunkRegionName) {
-    return createRegion(chunkRegionName, regionShortCut, fileRegionName, partitionAttributes);
+                           final PartitionAttributes partitionAttributes, final String chunkRegionName, final RegionAttributes regionAttributes) {
+    return createRegion(chunkRegionName, regionShortCut, fileRegionName, partitionAttributes, regionAttributes);
   }
 
   public String createChunkRegionName() {
@@ -173,8 +175,12 @@ public class LuceneIndexForPartitionedRegion extends LuceneIndexImpl {
     return attributesFactory;
   }
 
-  protected <K, V> Region<K, V> createRegion(final String regionName, final RegionShortcut regionShortCut,
-      final String colocatedWithRegionName, final PartitionAttributes partitionAttributes) {
+  protected <K, V> Region<K, V> createRegion(final String regionName,
+                                             final RegionShortcut regionShortCut,
+                                             final String colocatedWithRegionName,
+                                             final PartitionAttributes partitionAttributes,
+                                             final RegionAttributes regionAttributes)
+  {
     PartitionAttributesFactory partitionAttributesFactory = new PartitionAttributesFactory<String, File>();
     partitionAttributesFactory.setColocatedWith(colocatedWithRegionName);
     configureLuceneRegionAttributesFactory(partitionAttributesFactory, partitionAttributes);
@@ -183,6 +189,7 @@ public class LuceneIndexForPartitionedRegion extends LuceneIndexImpl {
     RegionAttributes baseAttributes = this.cache.getRegionAttributes(regionShortCut.toString());
     AttributesFactory factory = new AttributesFactory(baseAttributes);
     factory.setPartitionAttributes(partitionAttributesFactory.create());
+    factory.setDiskStoreName(regionAttributes.getDiskStoreName());
     RegionAttributes<K, V> attributes = factory.create();
 
     return createRegion(regionName, attributes);

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/LuceneIndexForPartitionedRegionTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/LuceneIndexForPartitionedRegionTest.java
@@ -214,8 +214,8 @@ public class LuceneIndexForPartitionedRegionTest {
     LuceneIndexForPartitionedRegion index = new LuceneIndexForPartitionedRegion(name, regionPath, cache);
     index.setSearchableFields(new String[]{"field"});
     LuceneIndexForPartitionedRegion spy = spy(index);
-    doReturn(null).when(spy).createFileRegion(any(), any(), any());
-    doReturn(null).when(spy).createChunkRegion(any(), any(), any(), any());
+    doReturn(null).when(spy).createFileRegion(any(), any(), any(), any());
+    doReturn(null).when(spy).createChunkRegion(any(), any(), any(), any(), any());
     doReturn(null).when(spy).createAEQ(eq(region));
     spy.initialize();
 
@@ -233,12 +233,12 @@ public class LuceneIndexForPartitionedRegionTest {
     LuceneIndexForPartitionedRegion index = new LuceneIndexForPartitionedRegion(name, regionPath, cache);
     index.setSearchableFields(new String[]{"field"});
     LuceneIndexForPartitionedRegion spy = spy(index);
-    doReturn(null).when(spy).createFileRegion(any(), any(), any());
-    doReturn(null).when(spy).createChunkRegion(any(), any(), any(), any());
+    doReturn(null).when(spy).createFileRegion(any(), any(), any(),any());
+    doReturn(null).when(spy).createChunkRegion(any(), any(), any(), any(),any());
     doReturn(null).when(spy).createAEQ(eq(region));
     spy.initialize();
 
-    verify(spy).createChunkRegion(eq(RegionShortcut.PARTITION), eq(index.createFileRegionName()), any(), eq(index.createChunkRegionName()));
+    verify(spy).createChunkRegion(eq(RegionShortcut.PARTITION), eq(index.createFileRegionName()), any(), eq(index.createChunkRegionName()),any());
   }
 
   @Test
@@ -252,12 +252,12 @@ public class LuceneIndexForPartitionedRegionTest {
     LuceneIndexForPartitionedRegion index = new LuceneIndexForPartitionedRegion(name, regionPath, cache);
     index.setSearchableFields(new String[]{"field"});
     LuceneIndexForPartitionedRegion spy = spy(index);
-    doReturn(null).when(spy).createFileRegion(any(), any(), any());
-    doReturn(null).when(spy).createChunkRegion(any(), any(), any(), any());
+    doReturn(null).when(spy).createFileRegion(any(), any(), any(),any());
+    doReturn(null).when(spy).createChunkRegion(any(), any(), any(), any(),any());
     doReturn(null).when(spy).createAEQ(eq(region));
     spy.initialize();
 
-    verify(spy).createFileRegion(eq(RegionShortcut.PARTITION), eq(index.createFileRegionName()), any());
+    verify(spy).createFileRegion(eq(RegionShortcut.PARTITION), eq(index.createFileRegionName()), any(),any());
   }
 
   @Test
@@ -265,12 +265,13 @@ public class LuceneIndexForPartitionedRegionTest {
     String name = "indexName";
     String regionPath = "regionName";
     GemFireCacheImpl cache = Fakes.cache();
+    RegionAttributes regionAttributes = mock(RegionAttributes.class);
     PartitionAttributes partitionAttributes = initializeAttributes(cache);
     LuceneIndexForPartitionedRegion index = new LuceneIndexForPartitionedRegion(name, regionPath, cache);
     LuceneIndexForPartitionedRegion indexSpy = spy(index);
-    indexSpy.createFileRegion(RegionShortcut.PARTITION, index.createFileRegionName(), partitionAttributes);
+    indexSpy.createFileRegion(RegionShortcut.PARTITION, index.createFileRegionName(), partitionAttributes, regionAttributes);
     String fileRegionName = index.createFileRegionName();
-    verify(indexSpy).createRegion(fileRegionName, RegionShortcut.PARTITION, regionPath, partitionAttributes);
+    verify(indexSpy).createRegion(fileRegionName, RegionShortcut.PARTITION, regionPath, partitionAttributes, regionAttributes);
     verify(cache).createVMRegion(eq(fileRegionName), any(), any());
   }
 
@@ -280,12 +281,13 @@ public class LuceneIndexForPartitionedRegionTest {
     String regionPath = "regionName";
     GemFireCacheImpl cache = Fakes.cache();
     PartitionAttributes partitionAttributes = initializeAttributes(cache);
+    RegionAttributes regionAttributes = mock(RegionAttributes.class);
     LuceneIndexForPartitionedRegion index = new LuceneIndexForPartitionedRegion(name, regionPath, cache);
     LuceneIndexForPartitionedRegion indexSpy = spy(index);
     String chunkRegionName = index.createChunkRegionName();
     String fileRegionName = index.createFileRegionName();
-    indexSpy.createChunkRegion(RegionShortcut.PARTITION, fileRegionName, partitionAttributes, chunkRegionName);
-    verify(indexSpy).createRegion(chunkRegionName, RegionShortcut.PARTITION, fileRegionName, partitionAttributes);
+    indexSpy.createChunkRegion(RegionShortcut.PARTITION, fileRegionName, partitionAttributes, chunkRegionName, regionAttributes);
+    verify(indexSpy).createRegion(chunkRegionName, RegionShortcut.PARTITION, fileRegionName, partitionAttributes, regionAttributes);
     verify(cache).createVMRegion(eq(chunkRegionName), any(), any());
   }
 
@@ -300,12 +302,12 @@ public class LuceneIndexForPartitionedRegionTest {
     LuceneIndexForPartitionedRegion index = new LuceneIndexForPartitionedRegion(name, regionPath, cache);
     index.setSearchableFields(new String[]{"field"});
     LuceneIndexForPartitionedRegion spy = spy(index);
-    doReturn(null).when(spy).createFileRegion(any(), any(), any());
-    doReturn(null).when(spy).createChunkRegion(any(), any(), any(), any());
+    doReturn(null).when(spy).createFileRegion(any(), any(), any(), any());
+    doReturn(null).when(spy).createChunkRegion(any(), any(), any(), any(), any());
     doReturn(null).when(spy).createAEQ(any());
     spy.initialize();
 
-    verify(spy).createChunkRegion(eq(RegionShortcut.PARTITION_PERSISTENT), eq(index.createFileRegionName()), any(), eq(index.createChunkRegionName()));
+    verify(spy).createChunkRegion(eq(RegionShortcut.PARTITION_PERSISTENT), eq(index.createFileRegionName()), any(), eq(index.createChunkRegionName()), any());
   }
 
   @Test
@@ -319,12 +321,12 @@ public class LuceneIndexForPartitionedRegionTest {
     LuceneIndexForPartitionedRegion index = new LuceneIndexForPartitionedRegion(name, regionPath, cache);
     index.setSearchableFields(new String[]{"field"});
     LuceneIndexForPartitionedRegion spy = spy(index);
-    doReturn(null).when(spy).createFileRegion(any(), any(), any());
-    doReturn(null).when(spy).createChunkRegion(any(), any(), any(), any());
+    doReturn(null).when(spy).createFileRegion(any(), any(), any(), any());
+    doReturn(null).when(spy).createChunkRegion(any(), any(), any(), any(), any());
     doReturn(null).when(spy).createAEQ(any());
     spy.initialize();
 
-    verify(spy).createFileRegion(eq(RegionShortcut.PARTITION_PERSISTENT), eq(index.createFileRegionName()), any());
+    verify(spy).createFileRegion(eq(RegionShortcut.PARTITION_PERSISTENT), eq(index.createFileRegionName()), any(), any());
   }
 
   @Test
@@ -338,13 +340,13 @@ public class LuceneIndexForPartitionedRegionTest {
     LuceneIndexForPartitionedRegion index = new LuceneIndexForPartitionedRegion(name, regionPath, cache);
     index.setSearchableFields(new String[]{"field"});
     LuceneIndexForPartitionedRegion spy = spy(index);
-    doReturn(null).when(spy).createFileRegion(any(), any(), any());
-    doReturn(null).when(spy).createChunkRegion(any(), any(), any(), any());
+    doReturn(null).when(spy).createFileRegion(any(), any(), any(), any());
+    doReturn(null).when(spy).createChunkRegion(any(), any(), any(), any(), any());
     doReturn(null).when(spy).createAEQ(any());
     spy.initialize();
     spy.initialize();
 
-    verify(spy).createFileRegion(eq(RegionShortcut.PARTITION_PERSISTENT), eq(index.createFileRegionName()), any());
+    verify(spy).createFileRegion(eq(RegionShortcut.PARTITION_PERSISTENT), eq(index.createFileRegionName()), any(), any());
   }
 
   @Test


### PR DESCRIPTION
The index and AEQ were stored in the default disk store. Changed the code to set the RegionAtrributes of the index and AEQ to use the same Disk Store Name as the region. Added a test to verify the disk store name.

Signed-off-by: Dan Smith <dsmith@pivotal.io>