### PR TITLE
GEODE-1598: fix auto-completion problems

### DIFF
--- a/geode-core/src/main/java/com/gemstone/gemfire/management/internal/cli/parser/jopt/JoptOptionParser.java
+++ b/geode-core/src/main/java/com/gemstone/gemfire/management/internal/cli/parser/jopt/JoptOptionParser.java
@@ -103,9 +103,10 @@ public class JoptOptionParser implements GfshOptionParser {
       argumentSpecs = optionBuilder.withOptionalArg();
     }
 
-    if (option.isRequired()) {
-      argumentSpecs.required();
-    }
+    // TODO: temporarily commented out as workaround for GEODE-1598
+    // if (option.isRequired()) {
+    //   argumentSpecs.required();
+    // }
     if (option.getValueSeparator() != null) {
       argumentSpecs.withValuesSeparatedBy(option.getValueSeparator());
     }


### PR DESCRIPTION


Spring shell, jopt-simple and Geode GFSH code all duplicated the concept of required options. jopt-simple can be blind to this, which prevents OptionParser.parse from throwing an Exception when a required option is missing at time of hitting tab for auto-complete. This allows OptionParser to return an OptionSet containing all detected options which is necessary for auto-completion to behave correctly.