### PR TITLE
GEODE-1600: startLocatorAndDS takes 0 as port number parameter

### DIFF
--- a/geode-core/src/main/java/com/gemstone/gemfire/distributed/internal/AbstractDistributionConfig.java
+++ b/geode-core/src/main/java/com/gemstone/gemfire/distributed/internal/AbstractDistributionConfig.java
@@ -322,7 +322,10 @@ public abstract class AbstractDistributionConfig
       int portVal = 0;
       try {
         portVal = Integer.parseInt(port);
-        if (portVal < 1 || portVal > 65535) {
+        if(0 == portVal){
+          return "";
+        }
+        else if (portVal < 1 || portVal > 65535) {
           throw new IllegalArgumentException(LocalizedStrings.AbstractDistributionConfig_INVALID_LOCATOR_0_THE_PORT_1_WAS_NOT_GREATER_THAN_ZERO_AND_LESS_THAN_65536.toLocalizedString(new Object[] {value, Integer.valueOf(portVal)}));
         }
       } catch (NumberFormatException ex) {

--- a/geode-core/src/main/java/com/gemstone/gemfire/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/com/gemstone/gemfire/distributed/internal/InternalLocator.java
@@ -603,6 +603,14 @@ public class InternalLocator extends Locator implements ConnectListener {
         this.handler, new DelayedPoolStatHelper(), group, this.toString());
   }
 
+  //Reset the file names with the correct port number if startLocatorAndDS was called with port number 0
+  public void resetInternalLocatorFileNamesWithCorrectPortNumber(int port){
+    this.stateFile = new File("locator" + port + "view.dat");
+    File productUseFile = new File("locator"+port+"views.log");
+    this.productUseLog = new ProductUseLog(productUseFile);
+  }
+
+
   private void startTcpServer() throws IOException {
     logger.info(LocalizedMessage.create(LocalizedStrings.InternalLocator_STARTING_0, this));
     server.start();


### PR DESCRIPTION
        * Use of getAvailableTCP port led to race conditions which led to locators being assigned ports in use.
        * Use of 0 now assignes a port number to the locator after the server is started.
        * Code modification to accept 0 as a valid port number until a real port number is assigned after the server is started.