### PR TITLE
Feature/geode 11 gfsh list lucene stats

### DIFF
--- a/geode-core/src/main/java/com/gemstone/gemfire/management/internal/cli/CliUtil.java
+++ b/geode-core/src/main/java/com/gemstone/gemfire/management/internal/cli/CliUtil.java
@@ -359,6 +359,38 @@ public class CliUtil {
     return stackAsString;
   }
 
+  @SuppressWarnings("unchecked")
+  public static <K> Class<K> forName(String classToLoadName, String neededFor) {
+    Class<K> loadedClass = null;
+    try {
+      // Set Constraints
+      ClassPathLoader classPathLoader = ClassPathLoader.getLatest();
+      if (classToLoadName != null && !classToLoadName.isEmpty()) {
+        loadedClass = (Class<K>) classPathLoader.forName(classToLoadName);
+      }
+    } catch (ClassNotFoundException | NoClassDefFoundError e) {
+      throw new RuntimeException(CliStrings.format(CliStrings.CREATE_REGION__MSG__COULDNOT_FIND_CLASS_0_SPECIFIED_FOR_1, new Object[] {classToLoadName, neededFor}), e);
+    }
+    catch (ClassCastException e) {
+      throw new RuntimeException(CliStrings.format(CliStrings.CREATE_REGION__MSG__CLASS_SPECIFIED_FOR_0_SPECIFIED_FOR_1_IS_NOT_OF_EXPECTED_TYPE, new Object[] {classToLoadName, neededFor}), e);
+    }
+
+    return loadedClass;
+  }
+
+  public static <K> K newInstance(Class<K> klass, String neededFor) {
+    K instance = null;
+    try {
+      instance = klass.newInstance();
+    } catch (InstantiationException e) {
+      throw new RuntimeException(CliStrings.format(CliStrings.CREATE_REGION__MSG__COULDNOT_INSTANTIATE_CLASS_0_SPECIFIED_FOR_1, new Object[] {klass, neededFor}), e);
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(CliStrings.format(CliStrings.CREATE_REGION__MSG__COULDNOT_ACCESS_CLASS_0_SPECIFIED_FOR_1, new Object[] {klass, neededFor}), e);
+    }
+
+    return instance;
+  }
+
   static class CustomFileFilter implements FileFilter {
     private String extensionWithDot;
 

--- a/geode-core/src/main/java/com/gemstone/gemfire/management/internal/cli/functions/RegionCreateFunction.java
+++ b/geode-core/src/main/java/com/gemstone/gemfire/management/internal/cli/functions/RegionCreateFunction.java
@@ -37,7 +37,6 @@ import com.gemstone.gemfire.cache.execute.FunctionAdapter;
 import com.gemstone.gemfire.cache.execute.FunctionContext;
 import com.gemstone.gemfire.cache.execute.ResultSender;
 import com.gemstone.gemfire.compression.Compressor;
-import com.gemstone.gemfire.internal.ClassPathLoader;
 import com.gemstone.gemfire.internal.InternalEntity;
 import com.gemstone.gemfire.internal.cache.xmlcache.CacheXml;
 import com.gemstone.gemfire.internal.i18n.LocalizedStrings;
@@ -205,12 +204,12 @@ public class RegionCreateFunction extends FunctionAdapter implements InternalEnt
     final String keyConstraint = regionCreateArgs.getKeyConstraint();
     final String valueConstraint = regionCreateArgs.getValueConstraint();
     if (keyConstraint != null && !keyConstraint.isEmpty()) {
-      Class<K> keyConstraintClass = forName(keyConstraint, CliStrings.CREATE_REGION__KEYCONSTRAINT);
+      Class<K> keyConstraintClass = CliUtil.forName(keyConstraint, CliStrings.CREATE_REGION__KEYCONSTRAINT);
       factory.setKeyConstraint(keyConstraintClass);
     }
 
     if (valueConstraint != null && !valueConstraint.isEmpty()) {
-      Class<V> valueConstraintClass = forName(valueConstraint, CliStrings.CREATE_REGION__VALUECONSTRAINT);
+      Class<V> valueConstraintClass = CliUtil.forName(valueConstraint, CliStrings.CREATE_REGION__VALUECONSTRAINT);
       factory.setValueConstraint(valueConstraintClass);
     }
 
@@ -296,27 +295,27 @@ public class RegionCreateFunction extends FunctionAdapter implements InternalEnt
     final Set<String> cacheListeners = regionCreateArgs.getCacheListeners();
     if (cacheListeners != null && !cacheListeners.isEmpty()) {
       for (String cacheListener : cacheListeners) {
-        Class<CacheListener<K, V>> cacheListenerKlass = forName(cacheListener, CliStrings.CREATE_REGION__CACHELISTENER);
-        factory.addCacheListener(newInstance(cacheListenerKlass, CliStrings.CREATE_REGION__CACHELISTENER));
+        Class<CacheListener<K, V>> cacheListenerKlass = CliUtil.forName(cacheListener, CliStrings.CREATE_REGION__CACHELISTENER);
+        factory.addCacheListener(CliUtil.newInstance(cacheListenerKlass, CliStrings.CREATE_REGION__CACHELISTENER));
       }
     }
 
     // Compression provider
     if(regionCreateArgs.isSetCompressor()) {
-      Class<Compressor> compressorKlass = forName(regionCreateArgs.getCompressor(), CliStrings.CREATE_REGION__COMPRESSOR);
-      factory.setCompressor(newInstance(compressorKlass, CliStrings.CREATE_REGION__COMPRESSOR));
+      Class<Compressor> compressorKlass = CliUtil.forName(regionCreateArgs.getCompressor(), CliStrings.CREATE_REGION__COMPRESSOR);
+      factory.setCompressor(CliUtil.newInstance(compressorKlass, CliStrings.CREATE_REGION__COMPRESSOR));
     }
     
     final String cacheLoader = regionCreateArgs.getCacheLoader();
     if (cacheLoader != null) {
-      Class<CacheLoader<K, V>> cacheLoaderKlass = forName(cacheLoader, CliStrings.CREATE_REGION__CACHELOADER);
-      factory.setCacheLoader(newInstance(cacheLoaderKlass, CliStrings.CREATE_REGION__CACHELOADER));
+      Class<CacheLoader<K, V>> cacheLoaderKlass = CliUtil.forName(cacheLoader, CliStrings.CREATE_REGION__CACHELOADER);
+      factory.setCacheLoader(CliUtil.newInstance(cacheLoaderKlass, CliStrings.CREATE_REGION__CACHELOADER));
     }
 
     final String cacheWriter = regionCreateArgs.getCacheWriter();
     if (cacheWriter != null) {
-      Class<CacheWriter<K, V>> cacheWriterKlass = forName(cacheWriter, CliStrings.CREATE_REGION__CACHEWRITER);
-      factory.setCacheWriter(newInstance(cacheWriterKlass, CliStrings.CREATE_REGION__CACHEWRITER));
+      Class<CacheWriter<K, V>> cacheWriterKlass = CliUtil.forName(cacheWriter, CliStrings.CREATE_REGION__CACHEWRITER);
+      factory.setCacheWriter(CliUtil.newInstance(cacheWriterKlass, CliStrings.CREATE_REGION__CACHEWRITER));
     }
     
     String regionName = regionPathData.getName();
@@ -374,38 +373,6 @@ public class RegionCreateFunction extends FunctionAdapter implements InternalEnt
     }
 
     return prAttrFactory.create();
-  }
-
-  @SuppressWarnings("unchecked")
-  private static <K> Class<K> forName(String classToLoadName, String neededFor) {
-    Class<K> loadedClass = null;
-    try {
-      // Set Constraints
-      ClassPathLoader classPathLoader = ClassPathLoader.getLatest();
-      if (classToLoadName != null && !classToLoadName.isEmpty()) {
-        loadedClass = (Class<K>) classPathLoader.forName(classToLoadName);
-      }
-    } catch (ClassNotFoundException | NoClassDefFoundError e) {
-      throw new RuntimeException(CliStrings.format(CliStrings.CREATE_REGION__MSG__COULDNOT_FIND_CLASS_0_SPECIFIED_FOR_1, new Object[] {classToLoadName, neededFor}), e);
-    }
-    catch (ClassCastException e) {
-      throw new RuntimeException(CliStrings.format(CliStrings.CREATE_REGION__MSG__CLASS_SPECIFIED_FOR_0_SPECIFIED_FOR_1_IS_NOT_OF_EXPECTED_TYPE, new Object[] {classToLoadName, neededFor}), e);
-    }
-
-    return loadedClass;
-  }
-
-  private static <K> K newInstance(Class<K> klass, String neededFor) {
-    K instance = null;
-    try {
-      instance = klass.newInstance();
-    } catch (InstantiationException e) {
-      throw new RuntimeException(CliStrings.format(CliStrings.CREATE_REGION__MSG__COULDNOT_INSTANTIATE_CLASS_0_SPECIFIED_FOR_1, new Object[] {klass, neededFor}), e);
-    } catch (IllegalAccessException e) {
-      throw new RuntimeException(CliStrings.format(CliStrings.CREATE_REGION__MSG__COULDNOT_ACCESS_CLASS_0_SPECIFIED_FOR_1, new Object[] {klass, neededFor}), e);
-    }
-
-    return instance;
   }
 
   @Override

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneCliStrings.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneCliStrings.java
@@ -23,7 +23,9 @@ public class LuceneCliStrings {
   public static final String LUCENE_LIST_INDEX = "list lucene index";
   public static final String LUCENE_LIST_INDEX__HELP = "Display the list of lucene indexes created for all members.";
   public static final String LUCENE_LIST_INDEX__ERROR_MESSAGE = "An error occurred while collecting all lucene index information across the Geode cluster: %1$s";
-  public static final String LUCENE_LIST_INDEX__INDEXES_NOT_FOUND_MESSAGE = "No lucene indexes Found";
+  public static final String LUCENE_LIST_INDEX__INDEXES_NOT_FOUND_MESSAGE = "No lucene indexes found";
+  public static final String LUCENE_LIST_INDEX__STATS = "stats";
+  public static final String LUCENE_LIST_INDEX__STATS__HELP = "Display lucene index stats";
 
   public static final String LUCENE_CREATE_INDEX = "create lucene index";
   public static final String LUCENE_CREATE_INDEX__HELP = "Create a lucene index that can be used to execute queries.";

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneCliStrings.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneCliStrings.java
@@ -20,10 +20,41 @@ package com.gemstone.gemfire.cache.lucene.internal.cli;
 
 public class LuceneCliStrings {
   //List Lucene Index commands
-  public static final String LUCENE_LIST_INDEX = "Lucene list indexes";
+  public static final String LUCENE_LIST_INDEX = "list lucene indexes";
   public static final String LUCENE_LIST_INDEX__HELP = "Display the list of Lucene indexes created for all members.";
   public static final String LUCENE_LIST_INDEX__ERROR_MESSAGE = "An error occurred while collecting all Lucene Index information across the Geode cluster: %1$s";
   public static final String LUCENE_LIST_INDEX__INDEXES_NOT_FOUND_MESSAGE = "No Lucene Indexes Found";
 
+  public static final String LUCENE_CREATE_INDEX = "create lucene index";
+  public static final String LUCENE_CREATE_INDEX__HELP = "Create an Lucene index that can be used when executing queries.";
+  public static final String LUCENE_CREATE_INDEX__NAME = "name";
+  public static final String LUCENE_CREATE_INDEX__NAME__HELP = "Name of the Lucene index to create.";
+  public static final String LUCENE_CREATE_INDEX__REGION = "region";
+  public static final String LUCENE_CREATE_INDEX__REGION_HELP = "Name/Path of the region where the Lucene index is created on.";
+  public static final String LUCENE_CREATE_INDEX__FIELD = "field";
+  public static final String LUCENE_CREATE_INDEX__FIELD_HELP = "fields on the region values on which are stored in the Lucene index.";
+  public static final String LUCENE_CREATE_INDEX__ANALYZER = "analyzer";
+  public static final String LUCENE_CREATE_INDEX__ANALYZER_HELP = "Type of the index. Valid values are: range, key and hash.";///
 
+  public static final String LUCENE_CREATE_INDEX__GROUP = "group";
+  public static final String LUCENE_CREATE_INDEX__GROUP__HELP = "Group of members in which the lucene index will be created.";
+
+  public static final String CREATE_INDEX__INVALID__INDEX__TYPE__MESSAGE = "Invalid index type,value must be one of the following: range, key or hash.";
+  public static final String CREATE_INDEX__SUCCESS__MSG = "Index successfully created with following details";
+  public static final String CREATE_INDEX__FAILURE__MSG = "Failed to create index \"{0}\" due to following reasons";
+  public static final String CREATE_INDEX__ERROR__MSG = "Exception \"{0}\" occured on following members";
+  public static final String CREATE_INDEX__NAME__CONFLICT = "Index \"{0}\" already exists.  "
+    + "Create failed due to duplicate name.";
+  public static final String CREATE_INDEX__INDEX__EXISTS = "Index \"{0}\" already exists.  "
+    + "Create failed due to duplicate definition.";
+  public static final String CREATE_INDEX__INVALID__EXPRESSION = "Invalid indexed expression : \"{0}\"";
+  public static final String CREATE_INDEX__INVALID__REGIONPATH = "Region not found : \"{0}\"";
+  public static final String CREATE_INDEX__NAME__MSG = "Name       : {0}";
+  public static final String CREATE_INDEX__EXPRESSION__MSG = "Expression : {0}";
+  public static final String CREATE_INDEX__REGIONPATH__MSG = "RegionPath : {0}";
+  public static final String CREATE_INDEX__TYPE__MSG = "Type       : {0}";
+  public static final String CREATE_INDEX__MEMBER__MSG = "Members which contain the index";
+  public static final String CREATE_INDEX__NUMBER__AND__MEMBER = "{0}. {1}";
+  public static final String CREATE_INDEX__EXCEPTION__OCCURRED__ON = "Occurred on following members";
+  public static final String CREATE_INDEX__INVALID__INDEX__NAME = "Invalid index name";
 }

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneCliStrings.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneCliStrings.java
@@ -19,9 +19,8 @@
 package com.gemstone.gemfire.cache.lucene.internal.cli;
 
 public class LuceneCliStrings {
-  public static final String LIST_INDEX = "list lucene indexes";
-  public static final String LIST_INDEX__HELP = "Display the list of lucene indexes created for all members.";
-  public static final String LIST_INDEX__ERROR_MESSAGE = "An error occurred while collecting all lucene index information across the Geode cluster: %1$s";
-  public static final String LIST_INDEX__INDEXES_NOT_FOUND_MESSAGE = "No lucene indexes Found";
-
-}
+  public static final String LUCENE_LIST_INDEX = "lucene list indexes";
+  public static final String LUCENE_LIST_INDEX__HELP = "Display the list of lucene indexes created for all members.";
+  public static final String LUCENE_LIST_INDEX__ERROR_MESSAGE = "An error occurred while collecting all lucene Index information across the Geode cluster: %1$s";
+  public static final String LUCENE_LIST_INDEX__INDEXES_NOT_FOUND_MESSAGE = "No Lucene Indexes Found";
+  }

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneCliStrings.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneCliStrings.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.gemstone.gemfire.cache.lucene.internal.cli;
+
+public class LuceneCliStrings {
+  public static final String LIST_INDEX = "list lucene indexes";
+  public static final String LIST_INDEX__HELP = "Display the list of lucene indexes created for all members.";
+  public static final String LIST_INDEX__ERROR_MESSAGE = "An error occurred while collecting all lucene index information across the Geode cluster: %1$s";
+  public static final String LIST_INDEX__INDEXES_NOT_FOUND_MESSAGE = "No lucene indexes Found";
+
+}

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneCliStrings.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneCliStrings.java
@@ -19,7 +19,11 @@
 package com.gemstone.gemfire.cache.lucene.internal.cli;
 
 public class LuceneCliStrings {
-  //List Lucene Index commands
+  //Common parameters/options
+  public static final String LUCENE__INDEX_NAME = "name";
+  public static final String LUCENE__REGION_PATH = "region";
+
+  //List lucene index commands
   public static final String LUCENE_LIST_INDEX = "list lucene index";
   public static final String LUCENE_LIST_INDEX__HELP = "Display the list of lucene indexes created for all members.";
   public static final String LUCENE_LIST_INDEX__ERROR_MESSAGE = "An error occurred while collecting all lucene index information across the Geode cluster: %1$s";
@@ -27,11 +31,10 @@ public class LuceneCliStrings {
   public static final String LUCENE_LIST_INDEX__STATS = "stats";
   public static final String LUCENE_LIST_INDEX__STATS__HELP = "Display lucene index stats";
 
+  //Create lucene index commands 
   public static final String LUCENE_CREATE_INDEX = "create lucene index";
   public static final String LUCENE_CREATE_INDEX__HELP = "Create a lucene index that can be used to execute queries.";
-  public static final String LUCENE_CREATE_INDEX__NAME = "name";
   public static final String LUCENE_CREATE_INDEX__NAME__HELP = "Name of the lucene index to create.";
-  public static final String LUCENE_CREATE_INDEX__REGION = "region";
   public static final String LUCENE_CREATE_INDEX__REGION_HELP = "Name/Path of the region where the lucene index is created on.";
   public static final String LUCENE_CREATE_INDEX__FIELD = "field";
   public static final String LUCENE_CREATE_INDEX__FIELD_HELP = "fields on the region values which are stored in the lucene index.";
@@ -39,7 +42,6 @@ public class LuceneCliStrings {
   public static final String LUCENE_CREATE_INDEX__ANALYZER_HELP = "Type of the analyzer for each field.";
   public static final String LUCENE_CREATE_INDEX__GROUP = "group";
   public static final String LUCENE_CREATE_INDEX__GROUP__HELP = "Group of members in which the lucene index will be created.";
-
   public static final String CREATE_INDEX__SUCCESS__MSG = "Index successfully created with following details";
   public static final String CREATE_INDEX__FAILURE__MSG = "Failed to create index \"{0}\" due to following reasons";
   public static final String CREATE_INDEX__NAME__MSG = "Name       : {0}";
@@ -47,4 +49,14 @@ public class LuceneCliStrings {
   public static final String CREATE_INDEX__MEMBER__MSG = "Members which contain the index";
   public static final String CREATE_INDEX__NUMBER__AND__MEMBER = "{0}. {1}";
   public static final String CREATE_INDEX__EXCEPTION__OCCURRED__ON = "Occurred on following members";
+  
+  //Describe lucene index commands
+  public static final String LUCENE_DESCRIBE_INDEX = "describe lucene index";
+  public static final String LUCENE_DESCRIBE_INDEX__HELP = "Display the describe of lucene indexes created for all members.";
+  public static final String LUCENE_DESCRIBE_INDEX__ERROR_MESSAGE = "An error occurred while collecting lucene index information across the Geode cluster: %1$s";
+  public static final String LUCENE_DESCRIBE_INDEX__NAME__HELP = "Name of the lucene index to describe.";
+  public static final String LUCENE_DESCRIBE_INDEX__REGION_HELP = "Name/Path of the region where the lucene index to be described exists.";
+
+
+
 }

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneCliStrings.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneCliStrings.java
@@ -19,8 +19,11 @@
 package com.gemstone.gemfire.cache.lucene.internal.cli;
 
 public class LuceneCliStrings {
-  public static final String LUCENE_LIST_INDEX = "lucene list indexes";
-  public static final String LUCENE_LIST_INDEX__HELP = "Display the list of lucene indexes created for all members.";
-  public static final String LUCENE_LIST_INDEX__ERROR_MESSAGE = "An error occurred while collecting all lucene Index information across the Geode cluster: %1$s";
+  //List Lucene Index commands
+  public static final String LUCENE_LIST_INDEX = "Lucene list indexes";
+  public static final String LUCENE_LIST_INDEX__HELP = "Display the list of Lucene indexes created for all members.";
+  public static final String LUCENE_LIST_INDEX__ERROR_MESSAGE = "An error occurred while collecting all Lucene Index information across the Geode cluster: %1$s";
   public static final String LUCENE_LIST_INDEX__INDEXES_NOT_FOUND_MESSAGE = "No Lucene Indexes Found";
-  }
+
+
+}

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneCliStrings.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneCliStrings.java
@@ -20,41 +20,29 @@ package com.gemstone.gemfire.cache.lucene.internal.cli;
 
 public class LuceneCliStrings {
   //List Lucene Index commands
-  public static final String LUCENE_LIST_INDEX = "list lucene indexes";
-  public static final String LUCENE_LIST_INDEX__HELP = "Display the list of Lucene indexes created for all members.";
-  public static final String LUCENE_LIST_INDEX__ERROR_MESSAGE = "An error occurred while collecting all Lucene Index information across the Geode cluster: %1$s";
-  public static final String LUCENE_LIST_INDEX__INDEXES_NOT_FOUND_MESSAGE = "No Lucene Indexes Found";
+  public static final String LUCENE_LIST_INDEX = "list lucene index";
+  public static final String LUCENE_LIST_INDEX__HELP = "Display the list of lucene indexes created for all members.";
+  public static final String LUCENE_LIST_INDEX__ERROR_MESSAGE = "An error occurred while collecting all lucene index information across the Geode cluster: %1$s";
+  public static final String LUCENE_LIST_INDEX__INDEXES_NOT_FOUND_MESSAGE = "No lucene indexes Found";
 
   public static final String LUCENE_CREATE_INDEX = "create lucene index";
-  public static final String LUCENE_CREATE_INDEX__HELP = "Create an Lucene index that can be used when executing queries.";
+  public static final String LUCENE_CREATE_INDEX__HELP = "Create a lucene index that can be used to execute queries.";
   public static final String LUCENE_CREATE_INDEX__NAME = "name";
-  public static final String LUCENE_CREATE_INDEX__NAME__HELP = "Name of the Lucene index to create.";
+  public static final String LUCENE_CREATE_INDEX__NAME__HELP = "Name of the lucene index to create.";
   public static final String LUCENE_CREATE_INDEX__REGION = "region";
-  public static final String LUCENE_CREATE_INDEX__REGION_HELP = "Name/Path of the region where the Lucene index is created on.";
+  public static final String LUCENE_CREATE_INDEX__REGION_HELP = "Name/Path of the region where the lucene index is created on.";
   public static final String LUCENE_CREATE_INDEX__FIELD = "field";
-  public static final String LUCENE_CREATE_INDEX__FIELD_HELP = "fields on the region values on which are stored in the Lucene index.";
+  public static final String LUCENE_CREATE_INDEX__FIELD_HELP = "fields on the region values which are stored in the lucene index.";
   public static final String LUCENE_CREATE_INDEX__ANALYZER = "analyzer";
-  public static final String LUCENE_CREATE_INDEX__ANALYZER_HELP = "Type of the index. Valid values are: range, key and hash.";///
-
+  public static final String LUCENE_CREATE_INDEX__ANALYZER_HELP = "Type of the analyzer for each field.";
   public static final String LUCENE_CREATE_INDEX__GROUP = "group";
   public static final String LUCENE_CREATE_INDEX__GROUP__HELP = "Group of members in which the lucene index will be created.";
 
-  public static final String CREATE_INDEX__INVALID__INDEX__TYPE__MESSAGE = "Invalid index type,value must be one of the following: range, key or hash.";
   public static final String CREATE_INDEX__SUCCESS__MSG = "Index successfully created with following details";
   public static final String CREATE_INDEX__FAILURE__MSG = "Failed to create index \"{0}\" due to following reasons";
-  public static final String CREATE_INDEX__ERROR__MSG = "Exception \"{0}\" occured on following members";
-  public static final String CREATE_INDEX__NAME__CONFLICT = "Index \"{0}\" already exists.  "
-    + "Create failed due to duplicate name.";
-  public static final String CREATE_INDEX__INDEX__EXISTS = "Index \"{0}\" already exists.  "
-    + "Create failed due to duplicate definition.";
-  public static final String CREATE_INDEX__INVALID__EXPRESSION = "Invalid indexed expression : \"{0}\"";
-  public static final String CREATE_INDEX__INVALID__REGIONPATH = "Region not found : \"{0}\"";
   public static final String CREATE_INDEX__NAME__MSG = "Name       : {0}";
-  public static final String CREATE_INDEX__EXPRESSION__MSG = "Expression : {0}";
   public static final String CREATE_INDEX__REGIONPATH__MSG = "RegionPath : {0}";
-  public static final String CREATE_INDEX__TYPE__MSG = "Type       : {0}";
   public static final String CREATE_INDEX__MEMBER__MSG = "Members which contain the index";
   public static final String CREATE_INDEX__NUMBER__AND__MEMBER = "{0}. {1}";
   public static final String CREATE_INDEX__EXCEPTION__OCCURRED__ON = "Occurred on following members";
-  public static final String CREATE_INDEX__INVALID__INDEX__NAME = "Invalid index name";
 }

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommands.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommands.java
@@ -71,9 +71,14 @@ public class LuceneIndexCommands extends AbstractCommandsSupport {
   @CliCommand(value = LuceneCliStrings.LUCENE_LIST_INDEX, help = LuceneCliStrings.LUCENE_LIST_INDEX__HELP)
   @CliMetaData(shellOnly = false, relatedTopic={CliStrings.TOPIC_GEODE_REGION, CliStrings.TOPIC_GEODE_DATA })
   @ResourceOperation(resource = Resource.CLUSTER, operation = OperationCode.READ)
-  public Result listIndex() {
+  public Result listIndex(
+    @CliOption(key = LuceneCliStrings.LUCENE_LIST_INDEX__STATS,
+      mandatory=false,
+      specifiedDefaultValue = "true",
+      unspecifiedDefaultValue = "false",
+      help = LuceneCliStrings.LUCENE_LIST_INDEX__STATS__HELP) final boolean stats) {
     try {
-      return toTabularResult(getIndexListing());
+      return toTabularResult(getIndexListing(),stats);
     }
     catch (FunctionInvocationTargetException ignore) {
       return ResultBuilder.createGemFireErrorResult(CliStrings.format(CliStrings.COULD_NOT_EXECUTE_COMMAND_TRY_AGAIN,
@@ -108,7 +113,7 @@ public class LuceneIndexCommands extends AbstractCommandsSupport {
       .collect(Collectors.toList());
   }
 
-  protected Result toTabularResult(final List<LuceneIndexDetails> indexDetailsList) {
+  protected Result toTabularResult(final List<LuceneIndexDetails> indexDetailsList, boolean stats) {
     if (!indexDetailsList.isEmpty()) {
       final TabularResultData indexData = ResultBuilder.createTabularResultData();
 
@@ -117,6 +122,13 @@ public class LuceneIndexCommands extends AbstractCommandsSupport {
         indexData.accumulate("Region Path", indexDetails.getRegionPath());
         indexData.accumulate("Indexed Fields", indexDetails.getSearchableFieldNamesString());
         indexData.accumulate("Field Analyzer", indexDetails.getFieldAnalyzersString());
+
+        if (stats==true) {
+          indexData.accumulate("Query Executions",indexDetails.getIndexStats().get("queryExecutions"));
+          indexData.accumulate("Updates",indexDetails.getIndexStats().get("updates"));
+          indexData.accumulate("Commits",indexDetails.getIndexStats().get("commits"));
+          indexData.accumulate("Documents",indexDetails.getIndexStats().get("documents"));
+        }
       }
       return ResultBuilder.buildResult(indexData);
     }

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommands.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommands.java
@@ -57,7 +57,7 @@ import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 
 /**
- * The LuceneIndexCommands class encapsulates all Geode shell (Gfsh) commands related to lucene indexes defined in Geode.
+ * The LuceneIndexCommands class encapsulates all Geode shell (Gfsh) commands related to Lucene indexes defined in Geode.
  * </p>
  * @see AbstractCommandsSupport
  * @see LuceneIndexDetails
@@ -124,8 +124,6 @@ public class LuceneIndexCommands extends AbstractCommandsSupport {
       return ResultBuilder.createInfoResult(LuceneCliStrings.LUCENE_LIST_INDEX__INDEXES_NOT_FOUND_MESSAGE);
     }
   }
-  //gfsh create lucene index --field=a,b,c
-  //gfsh create lucene index --field=a,b,c --analyzer=Standard,Keyword
 
   @CliCommand(value = LuceneCliStrings.LUCENE_CREATE_INDEX, help = LuceneCliStrings.LUCENE_CREATE_INDEX__HELP)
   @CliMetaData(shellOnly = false, relatedTopic={CliStrings.TOPIC_GEODE_REGION, CliStrings.TOPIC_GEODE_DATA }, writesToSharedConfiguration=true)
@@ -162,11 +160,11 @@ public class LuceneIndexCommands extends AbstractCommandsSupport {
 
     GeodeSecurityUtil.authorizeRegionManage(regionPath);
     try {
-      final Cache cache = CacheFactory.getAnyInstance();
-      final Set<DistributedMember> targetMembers = CliUtil.findAllMatchingMembers(groups, null);
+      final Cache cache = getCache();
       LuceneIndexInfo indexInfo = new LuceneIndexInfo(indexName, regionPath, fields, analyzers);
-      final ResultCollector<?, ?> rc = CliUtil.executeFunction(createIndexFunction, indexInfo, targetMembers);
+      final ResultCollector<?, ?> rc = this.createIndexOnGroups(groups, indexInfo);
       final List<CliFunctionResult> funcResults = (List<CliFunctionResult>) rc.getResult();
+
       final Set<String> successfulMembers = new TreeSet<String>();
       final Map<String, Set<String>> indexOpFailMap = new HashMap<String, Set<String>>();
 
@@ -207,6 +205,7 @@ public class LuceneIndexCommands extends AbstractCommandsSupport {
         }
         result = ResultBuilder.buildResult(infoResult);
 
+
       } else {
         //Group members by the exception thrown.
         final ErrorResultData erd = ResultBuilder.createErrorResultData();
@@ -232,12 +231,16 @@ public class LuceneIndexCommands extends AbstractCommandsSupport {
     } catch (Exception e) {
       result = ResultBuilder.createGemFireErrorResult(e.getMessage());
     }
-
-    //TODO - store in cluster config
+//    TODO - store in cluster config
 //    if (xmlEntity != null) {
 //      result.setCommandPersisted((new SharedConfigurationWriter()).addXmlEntity(xmlEntity, groups));
 //    }
 
     return result;
+  }
+
+  protected ResultCollector<?, ?> createIndexOnGroups( String[] groups, final LuceneIndexInfo indexInfo) throws CommandResultException {
+    final Set<DistributedMember> targetMembers = CliUtil.findAllMatchingMembers(groups, null);
+    return CliUtil.executeFunction(createIndexFunction, indexInfo, targetMembers);
   }
 }

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommands.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommands.java
@@ -18,8 +18,6 @@ package com.gemstone.gemfire.cache.lucene.internal.cli;
 
 import static com.gemstone.gemfire.cache.operations.OperationContext.*;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,21 +28,19 @@ import java.util.stream.Collectors;
 import com.gemstone.gemfire.SystemFailure;
 import com.gemstone.gemfire.cache.Cache;
 import com.gemstone.gemfire.cache.CacheFactory;
-import com.gemstone.gemfire.cache.Region;
 import com.gemstone.gemfire.cache.execute.Execution;
 import com.gemstone.gemfire.cache.execute.FunctionInvocationTargetException;
 import com.gemstone.gemfire.cache.execute.ResultCollector;
+import com.gemstone.gemfire.cache.lucene.internal.cli.functions.LuceneCreateIndexFunction;
 import com.gemstone.gemfire.cache.lucene.internal.cli.functions.LuceneListIndexFunction;
 import com.gemstone.gemfire.distributed.DistributedMember;
 import com.gemstone.gemfire.internal.cache.execute.AbstractExecution;
-import com.gemstone.gemfire.internal.lang.StringUtils;
 import com.gemstone.gemfire.internal.security.GeodeSecurityUtil;
 import com.gemstone.gemfire.management.cli.CliMetaData;
 import com.gemstone.gemfire.management.cli.ConverterHint;
 import com.gemstone.gemfire.management.cli.Result;
 import com.gemstone.gemfire.management.internal.cli.CliUtil;
 import com.gemstone.gemfire.management.internal.cli.commands.AbstractCommandsSupport;
-import com.gemstone.gemfire.management.internal.cli.domain.IndexDetails;
 
 import com.gemstone.gemfire.management.internal.cli.domain.IndexInfo;
 import com.gemstone.gemfire.management.internal.cli.functions.CliFunctionResult;
@@ -69,6 +65,8 @@ import org.springframework.shell.core.annotation.CliOption;
  */
 @SuppressWarnings("unused")
 public class LuceneIndexCommands extends AbstractCommandsSupport {
+
+  private static final LuceneCreateIndexFunction createIndexFunction = new LuceneCreateIndexFunction();
 
   @CliCommand(value = LuceneCliStrings.LUCENE_LIST_INDEX, help = LuceneCliStrings.LUCENE_LIST_INDEX__HELP)
   @CliMetaData(shellOnly = false, relatedTopic={CliStrings.TOPIC_GEODE_REGION, CliStrings.TOPIC_GEODE_DATA })
@@ -126,5 +124,120 @@ public class LuceneIndexCommands extends AbstractCommandsSupport {
       return ResultBuilder.createInfoResult(LuceneCliStrings.LUCENE_LIST_INDEX__INDEXES_NOT_FOUND_MESSAGE);
     }
   }
+  //gfsh create lucene index --field=a,b,c
+  //gfsh create lucene index --field=a,b,c --analyzer=Standard,Keyword
 
+  @CliCommand(value = LuceneCliStrings.LUCENE_CREATE_INDEX, help = LuceneCliStrings.LUCENE_CREATE_INDEX__HELP)
+  @CliMetaData(shellOnly = false, relatedTopic={CliStrings.TOPIC_GEODE_REGION, CliStrings.TOPIC_GEODE_DATA }, writesToSharedConfiguration=true)
+  //TODO : Add optionContext for indexName
+  public Result createIndex(
+    @CliOption(key = LuceneCliStrings.LUCENE_CREATE_INDEX__NAME,
+      mandatory=true,
+      help = LuceneCliStrings.LUCENE_CREATE_INDEX__NAME__HELP) final String indexName,
+
+    @CliOption (key = LuceneCliStrings.LUCENE_CREATE_INDEX__REGION,
+      mandatory = true,
+      optionContext = ConverterHint.REGIONPATH,
+      help = LuceneCliStrings.LUCENE_CREATE_INDEX__REGION_HELP) final String regionPath,
+
+    @CliOption(key = LuceneCliStrings.LUCENE_CREATE_INDEX__FIELD,
+      mandatory = true,
+      help = LuceneCliStrings.LUCENE_CREATE_INDEX__FIELD_HELP)
+    @CliMetaData (valueSeparator = ",") final String[] fields,
+
+    @CliOption(key = LuceneCliStrings.LUCENE_CREATE_INDEX__ANALYZER,
+      mandatory = false,
+      unspecifiedDefaultValue = CliMetaData.ANNOTATION_NULL_VALUE,
+      help = LuceneCliStrings.LUCENE_CREATE_INDEX__ANALYZER_HELP)
+    @CliMetaData (valueSeparator = ",") final String[] analyzers,
+
+    @CliOption (key = LuceneCliStrings.LUCENE_CREATE_INDEX__GROUP,
+      optionContext = ConverterHint.MEMBERGROUP,
+      unspecifiedDefaultValue = CliMetaData.ANNOTATION_NULL_VALUE,
+      help = LuceneCliStrings.LUCENE_CREATE_INDEX__GROUP__HELP)
+    @CliMetaData (valueSeparator = ",") final String[] groups) {
+
+    Result result = null;
+    XmlEntity xmlEntity = null;
+
+    GeodeSecurityUtil.authorizeRegionManage(regionPath);
+    try {
+      final Cache cache = CacheFactory.getAnyInstance();
+      final Set<DistributedMember> targetMembers = CliUtil.findAllMatchingMembers(groups, null);
+      LuceneIndexInfo indexInfo = new LuceneIndexInfo(indexName, regionPath, fields, analyzers);
+      final ResultCollector<?, ?> rc = CliUtil.executeFunction(createIndexFunction, indexInfo, targetMembers);
+      final List<CliFunctionResult> funcResults = (List<CliFunctionResult>) rc.getResult();
+      final Set<String> successfulMembers = new TreeSet<String>();
+      final Map<String, Set<String>> indexOpFailMap = new HashMap<String, Set<String>>();
+
+      for (final CliFunctionResult cliFunctionResult : funcResults) {
+
+          if (cliFunctionResult.isSuccessful()) {
+            successfulMembers.add(cliFunctionResult.getMemberIdOrName());
+
+            if (xmlEntity == null) {
+              xmlEntity = cliFunctionResult.getXmlEntity();
+            }
+          }
+          else {
+            final String exceptionMessage = cliFunctionResult.getMessage();
+            Set<String> failedMembers = indexOpFailMap.get(exceptionMessage);
+
+            if (failedMembers == null) {
+              failedMembers = new TreeSet<String>();
+            }
+            failedMembers.add(cliFunctionResult.getMemberIdOrName());
+            indexOpFailMap.put(exceptionMessage, failedMembers);
+          }
+      }
+
+      if (!successfulMembers.isEmpty()) {
+
+        final InfoResultData infoResult = ResultBuilder.createInfoResultData();
+        infoResult.addLine(LuceneCliStrings.CREATE_INDEX__SUCCESS__MSG);
+        infoResult.addLine(CliStrings.format(LuceneCliStrings.CREATE_INDEX__NAME__MSG, indexName));
+        infoResult.addLine(CliStrings.format(LuceneCliStrings.CREATE_INDEX__REGIONPATH__MSG, regionPath));
+        infoResult.addLine(LuceneCliStrings.CREATE_INDEX__MEMBER__MSG);
+
+        int num = 0;
+
+        for (final String memberId : successfulMembers) {
+          ++num;
+          infoResult.addLine(CliStrings.format(LuceneCliStrings.CREATE_INDEX__NUMBER__AND__MEMBER, num, memberId));
+        }
+        result = ResultBuilder.buildResult(infoResult);
+
+      } else {
+        //Group members by the exception thrown.
+        final ErrorResultData erd = ResultBuilder.createErrorResultData();
+        erd.addLine(CliStrings.format(LuceneCliStrings.CREATE_INDEX__FAILURE__MSG, indexName));
+
+        final Set<String> exceptionMessages = indexOpFailMap.keySet();
+
+        for (final String exceptionMessage : exceptionMessages) {
+          erd.addLine(exceptionMessage);
+          erd.addLine(LuceneCliStrings.CREATE_INDEX__EXCEPTION__OCCURRED__ON);
+          final Set<String> memberIds = indexOpFailMap.get(exceptionMessage);
+
+          int num = 0;
+          for (final String memberId : memberIds) {
+            ++num;
+            erd.addLine(CliStrings.format(LuceneCliStrings.CREATE_INDEX__NUMBER__AND__MEMBER, num, memberId));
+          }
+        }
+        result = ResultBuilder.buildResult(erd);
+      }
+    } catch (CommandResultException crex) {
+      result = crex.getResult();
+    } catch (Exception e) {
+      result = ResultBuilder.createGemFireErrorResult(e.getMessage());
+    }
+
+    //TODO - store in cluster config
+//    if (xmlEntity != null) {
+//      result.setCommandPersisted((new SharedConfigurationWriter()).addXmlEntity(xmlEntity, groups));
+//    }
+
+    return result;
+  }
 }

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommands.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommands.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.gemstone.gemfire.cache.lucene.internal.cli;
+
+
+import com.gemstone.gemfire.SystemFailure;
+import com.gemstone.gemfire.cache.execute.FunctionInvocationTargetException;
+import com.gemstone.gemfire.cache.operations.OperationContext.OperationCode;
+import com.gemstone.gemfire.cache.operations.OperationContext.Resource;
+import com.gemstone.gemfire.management.cli.CliMetaData;
+import com.gemstone.gemfire.management.cli.Result;
+import com.gemstone.gemfire.management.internal.cli.commands.AbstractCommandsSupport;
+import com.gemstone.gemfire.management.internal.cli.i18n.CliStrings;
+import com.gemstone.gemfire.management.internal.cli.result.ResultBuilder;
+import com.gemstone.gemfire.management.internal.cli.result.TabularResultData;
+import com.gemstone.gemfire.management.internal.security.ResourceOperation;
+
+import org.springframework.shell.core.annotation.CliCommand;
+import org.springframework.shell.core.annotation.CliOption;
+
+public class LuceneIndexCommands extends AbstractCommandsSupport {
+  @CliCommand(value = LuceneCliStrings.LIST_INDEX, help = LuceneCliStrings.LIST_INDEX__HELP)
+  @CliMetaData(shellOnly = false, relatedTopic={CliStrings.TOPIC_GEODE_REGION, CliStrings.TOPIC_GEODE_DATA })
+  @ResourceOperation(resource = Resource.CLUSTER, operation = OperationCode.READ)
+  public Result listIndex() {
+    try {
+      final TabularResultData indexData = ResultBuilder.createTabularResultData();
+      return ResultBuilder.buildResult(indexData);
+    }
+    catch (FunctionInvocationTargetException ignore) {
+      return ResultBuilder.createGemFireErrorResult(CliStrings.format(CliStrings.COULD_NOT_EXECUTE_COMMAND_TRY_AGAIN,
+        CliStrings.LIST_INDEX));
+    }
+    catch (VirtualMachineError e) {
+      SystemFailure.initiateFailure(e);
+      throw e;
+    }
+    catch (Throwable t) {
+      SystemFailure.checkFailure();
+      getCache().getLogger().error(t);
+      return ResultBuilder.createGemFireErrorResult(String.format(CliStrings.LIST_INDEX__ERROR_MESSAGE,
+        toString(t, isDebugging())));
+    }
+  }
+
+}

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommands.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommands.java
@@ -1,51 +1,65 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.gemstone.gemfire.cache.lucene.internal.cli;
 
+import static com.gemstone.gemfire.cache.operations.OperationContext.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 import com.gemstone.gemfire.SystemFailure;
+import com.gemstone.gemfire.cache.execute.Execution;
 import com.gemstone.gemfire.cache.execute.FunctionInvocationTargetException;
-import com.gemstone.gemfire.cache.operations.OperationContext.OperationCode;
-import com.gemstone.gemfire.cache.operations.OperationContext.Resource;
+import com.gemstone.gemfire.cache.execute.ResultCollector;
+import com.gemstone.gemfire.cache.lucene.internal.cli.functions.LuceneListIndexFunction;
+import com.gemstone.gemfire.internal.cache.execute.AbstractExecution;
 import com.gemstone.gemfire.management.cli.CliMetaData;
 import com.gemstone.gemfire.management.cli.Result;
 import com.gemstone.gemfire.management.internal.cli.commands.AbstractCommandsSupport;
+import com.gemstone.gemfire.management.internal.cli.domain.IndexDetails;
+
 import com.gemstone.gemfire.management.internal.cli.i18n.CliStrings;
 import com.gemstone.gemfire.management.internal.cli.result.ResultBuilder;
 import com.gemstone.gemfire.management.internal.cli.result.TabularResultData;
 import com.gemstone.gemfire.management.internal.security.ResourceOperation;
-
 import org.springframework.shell.core.annotation.CliCommand;
-import org.springframework.shell.core.annotation.CliOption;
 
+/**
+ * The LuceneIndexCommands class encapsulates all Geode shell (Gfsh) commands related to lucene indexes defined in Geode.
+ * </p>
+ * @see AbstractCommandsSupport
+ * @see LuceneIndexDetails
+ * @see LuceneListIndexFunction
+ */
+@SuppressWarnings("unused")
 public class LuceneIndexCommands extends AbstractCommandsSupport {
-  @CliCommand(value = LuceneCliStrings.LIST_INDEX, help = LuceneCliStrings.LIST_INDEX__HELP)
+
+  @CliCommand(value = LuceneCliStrings.LUCENE_LIST_INDEX, help = LuceneCliStrings.LUCENE_LIST_INDEX__HELP)
   @CliMetaData(shellOnly = false, relatedTopic={CliStrings.TOPIC_GEODE_REGION, CliStrings.TOPIC_GEODE_DATA })
   @ResourceOperation(resource = Resource.CLUSTER, operation = OperationCode.READ)
   public Result listIndex() {
     try {
-      final TabularResultData indexData = ResultBuilder.createTabularResultData();
-      return ResultBuilder.buildResult(indexData);
+      return toTabularResult(getIndexListing());
     }
     catch (FunctionInvocationTargetException ignore) {
       return ResultBuilder.createGemFireErrorResult(CliStrings.format(CliStrings.COULD_NOT_EXECUTE_COMMAND_TRY_AGAIN,
-        CliStrings.LIST_INDEX));
+        LuceneCliStrings.LUCENE_LIST_INDEX));
     }
     catch (VirtualMachineError e) {
       SystemFailure.initiateFailure(e);
@@ -54,8 +68,47 @@ public class LuceneIndexCommands extends AbstractCommandsSupport {
     catch (Throwable t) {
       SystemFailure.checkFailure();
       getCache().getLogger().error(t);
-      return ResultBuilder.createGemFireErrorResult(String.format(CliStrings.LIST_INDEX__ERROR_MESSAGE,
+      return ResultBuilder.createGemFireErrorResult(String.format(LuceneCliStrings.LUCENE_LIST_INDEX__ERROR_MESSAGE,
         toString(t, isDebugging())));
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  protected List<LuceneIndexDetails> getIndexListing() {
+    final Execution functionExecutor = getMembersFunctionExecutor(getMembers(getCache()));
+
+    if (functionExecutor instanceof AbstractExecution) {
+      ((AbstractExecution) functionExecutor).setIgnoreDepartedMembers(true);
+    }
+
+    final ResultCollector<?, ?> resultsCollector = functionExecutor.execute(new LuceneListIndexFunction());
+    final List<?> results = (List<?>) resultsCollector.getResult();
+    final List<LuceneIndexDetails> indexDetailsList = new ArrayList<>(results.size());
+
+    for (Object result : results) {
+      if (result instanceof Set) { // ignore FunctionInvocationTargetExceptions and other Exceptions
+        indexDetailsList.addAll((Set<LuceneIndexDetails>) result);
+      }
+    }
+    Collections.sort(indexDetailsList);
+    return indexDetailsList;
+  }
+
+  protected Result toTabularResult(final List<LuceneIndexDetails> indexDetailsList) {
+    if (!indexDetailsList.isEmpty()) {
+      final TabularResultData indexData = ResultBuilder.createTabularResultData();
+
+      for (final LuceneIndexDetails indexDetails : indexDetailsList) {
+        indexData.accumulate("Index Name", indexDetails.getIndexName());
+        indexData.accumulate("Region Path", indexDetails.getRegionPath());
+        indexData.accumulate("Analyzer", indexDetails.getAnalyzer());
+        indexData.accumulate("Indexed Fields", indexDetails.getSearchableFieldNamesString());
+        indexData.accumulate("Field Analyzer", indexDetails.getFieldAnalyzersString());
+      }
+      return ResultBuilder.buildResult(indexData);
+    }
+    else {
+      return ResultBuilder.createInfoResult(LuceneCliStrings.LUCENE_LIST_INDEX__INDEXES_NOT_FOUND_MESSAGE);
     }
   }
 

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexDetails.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexDetails.java
@@ -22,7 +22,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+
 import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexImpl;
+import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexStats;
 
 import org.apache.lucene.analysis.Analyzer;
 
@@ -33,16 +35,35 @@ public class LuceneIndexDetails implements Comparable<LuceneIndexDetails>, Seria
   private final String regionPath;
   private final String[] searchableFieldNames;
   private final Map<String, String> fieldAnalyzers;
+  private final Map<String,Integer> indexStats;
 
-  public LuceneIndexDetails(final String indexName, final String regionPath, final String[] searchableFieldNames, Map<String, Analyzer> fieldAnalyzers) {
+  public LuceneIndexDetails(final String indexName, final String regionPath, final String[] searchableFieldNames, Map<String, Analyzer> fieldAnalyzers, LuceneIndexStats indexStats) {
     this.indexName = indexName;
     this.regionPath = regionPath;
     this.searchableFieldNames = searchableFieldNames;
     this.fieldAnalyzers = getAnalyzerStrings(fieldAnalyzers);
+    this.indexStats=getIndexStatsMap(indexStats);
   }
 
   public LuceneIndexDetails(LuceneIndexImpl index) {
-    this(index.getName(), index.getRegionPath(), index.getFieldNames(), index.getFieldAnalyzers());
+    this(index.getName(), index.getRegionPath(), index.getFieldNames(), index.getFieldAnalyzers(),index.getIndexStats());
+  }
+
+  public Map<String,Integer> getIndexStats() {
+    return indexStats;
+  }
+  private  Map<String,Integer> getIndexStatsMap(LuceneIndexStats indexStats) {
+    Map<String,Integer> statsMap = new HashMap<>();
+    if (indexStats==null) return statsMap;
+    statsMap.put("queryExecutions",indexStats.getQueryExecutions());
+    statsMap.put("updates",indexStats.getUpdates());
+    statsMap.put("commits",indexStats.getCommits());
+    statsMap.put("documents",indexStats.getDocuments());
+    return statsMap;
+  }
+
+  private String getIndexStatsString() {
+    return indexStats.toString();
   }
 
   private Map<String, String> getAnalyzerStrings(Map<String, Analyzer> fieldAnalyzers) {
@@ -77,6 +98,7 @@ public class LuceneIndexDetails implements Comparable<LuceneIndexDetails>, Seria
     buffer.append(",\tRegion Path = "+regionPath);
     buffer.append(",\tIndexed Fields = "+getSearchableFieldNamesString());
     buffer.append(",\tField Analyzer = "+getFieldAnalyzersString());
+    buffer.append(",\tIndex Statistics =\n\t"+getIndexStatsString());
     buffer.append("\n}\n");
     return buffer.toString();
   }
@@ -88,10 +110,6 @@ public class LuceneIndexDetails implements Comparable<LuceneIndexDetails>, Seria
 
   public String getRegionPath() {
     return regionPath;
-  }
-
-  public String[] getSearchableFieldNames() {
-    return searchableFieldNames;
   }
 
   private static <T extends Comparable<T>> int compare(final T obj1, final T obj2) {

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexDetails.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexDetails.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gemstone.gemfire.cache.lucene.internal.cli;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexImpl;
+
+public class LuceneIndexDetails implements Comparable<LuceneIndexDetails>, Serializable {
+
+  private String indexName;
+  private String regionPath;
+  private String[] searchableFieldNames;
+  protected Class<?> analyzer;
+  private Map<String, Class<?>> fieldAnalyzers= new HashMap<String, Class<?>>();
+
+  public LuceneIndexDetails(LuceneIndexImpl index) {
+    indexName = index.getName();
+    regionPath = index.getRegionPath();
+    searchableFieldNames = index.getFieldNames();
+    analyzer = index.getAnalyzer().getClass();
+    setFieldAnalyzers(index);
+  }
+
+  private void setFieldAnalyzers(final LuceneIndexImpl index) {
+    if (index.getFieldAnalyzers() != null) {
+      for (Entry entry : index.getFieldAnalyzers().entrySet()) {
+        fieldAnalyzers.put(entry.getKey().toString(), entry.getValue().getClass());
+      }
+    }
+  }
+
+  public String getSearchableFieldNamesString() {
+    StringBuffer stringBuffer=new StringBuffer("[");
+    if (searchableFieldNames !=null) {
+      for (String field : searchableFieldNames) {
+        stringBuffer.append(field + ",");
+      }
+      stringBuffer.deleteCharAt(stringBuffer.length()-1);
+    }
+    return stringBuffer.append("]").toString();
+  }
+
+
+  public String getFieldAnalyzersString() {
+    StringBuffer stringBuffer=new StringBuffer("[");
+    if (!fieldAnalyzers.isEmpty()) {
+      for(Entry entry: fieldAnalyzers.entrySet()) {
+        stringBuffer.append("<"+entry.getKey()+","+entry.getValue()+">,");
+      }
+      stringBuffer.deleteCharAt(stringBuffer.length()-1);
+    }
+    return stringBuffer.append("]").toString();
+  }
+
+  @Override
+  public String toString() {
+    final StringBuffer buffer = new StringBuffer();
+    buffer.append("{\n\tIndex Name = "+indexName);
+    buffer.append(",\tRegion Path = "+regionPath);
+    buffer.append(",\tAnalyzer = "+analyzer);
+    buffer.append(",\tIndexed Fields = "+getSearchableFieldNamesString());
+    buffer.append(",\tField Analyzer = "+getFieldAnalyzersString());
+    buffer.append("\n}\n");
+    return buffer.toString();
+  }
+
+
+  public String getIndexName() {
+    return indexName;
+  }
+
+  public String getRegionPath() {
+    return regionPath;
+  }
+
+  public Map<String, Class<?>> getFieldAnalyzers() {
+    return fieldAnalyzers;
+  }
+
+  public Class<?> getAnalyzer() {
+    return analyzer;
+  }
+
+  public String[] getSearchableFieldNames() {
+    return searchableFieldNames;
+  }
+
+  private static <T extends Comparable<T>> int compare(final T obj1, final T obj2) {
+    return (obj1 == null && obj2 == null ? 0 : (obj1 == null ? 1 : (obj2 == null ? -1 : obj1.compareTo(obj2))));
+  }
+
+  @Override
+  public int compareTo(final LuceneIndexDetails indexDetails) {
+    int comparisonValue = compare(getIndexName(), indexDetails.getIndexName());
+    return (comparisonValue != 0 ? comparisonValue : compare(getRegionPath(), indexDetails.getRegionPath()));
+  }
+
+}

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexDetails.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexDetails.java
@@ -62,7 +62,7 @@ public class LuceneIndexDetails implements Comparable<LuceneIndexDetails>, Seria
     return statsMap;
   }
 
-  private String getIndexStatsString() {
+  public String getIndexStatsString() {
     return indexStats.toString();
   }
 

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexDetails.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexDetails.java
@@ -27,6 +27,7 @@ import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexImpl;
 import org.apache.lucene.analysis.Analyzer;
 
 public class LuceneIndexDetails implements Comparable<LuceneIndexDetails>, Serializable {
+  private static final long serialVersionUID = 1L;
 
   private final String indexName;
   private final String regionPath;

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexDetails.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexDetails.java
@@ -26,6 +26,13 @@ public class LuceneIndexDetails implements Comparable<LuceneIndexDetails>, Seria
 
   private String indexName;
   private String regionPath;
+
+  public LuceneIndexDetails(final String indexName, final String regionPath, final String[] searchableFieldNames) {
+    this.indexName = indexName;
+    this.regionPath = regionPath;
+    this.searchableFieldNames = searchableFieldNames;
+  }
+
   private String[] searchableFieldNames;
   protected Class<?> analyzer;
   private Map<String, Class<?>> fieldAnalyzers= new HashMap<String, Class<?>>();

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexInfo.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexInfo.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gemstone.gemfire.cache.lucene.internal.cli;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexImpl;
+
+import org.apache.lucene.analysis.Analyzer;
+
+public class LuceneIndexInfo implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private final String indexName;
+  private final String regionPath;
+  private final String[] searchableFieldNames;
+  private final String[] fieldAnalyzers;
+
+  public LuceneIndexInfo(final String indexName, final String regionPath, final String[] searchableFieldNames, String[] fieldAnalyzers) {
+    this.indexName = indexName;
+    this.regionPath = regionPath;
+    this.searchableFieldNames = searchableFieldNames;
+    this.fieldAnalyzers = fieldAnalyzers;
+  }
+
+  public String getIndexName() {
+    return indexName;
+  }
+
+  public String getRegionPath() {
+    return regionPath;
+  }
+
+  public String[] getSearchableFieldNames() {
+    return searchableFieldNames;
+  }
+
+  public String[] getFieldAnalyzers() {
+    return fieldAnalyzers;
+  }
+}

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexInfo.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexInfo.java
@@ -41,6 +41,10 @@ public class LuceneIndexInfo implements Serializable {
     this.fieldAnalyzers = fieldAnalyzers;
   }
 
+  public LuceneIndexInfo(final String indexName, final String regionPath) {
+    this(indexName,regionPath,null,null);
+  }
+
   public String getIndexName() {
     return indexName;
   }

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneCreateIndexFunction.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneCreateIndexFunction.java
@@ -43,8 +43,7 @@ import org.apache.lucene.analysis.Analyzer;
 
 
 /**
- * The LuceneListIndexFunction class is a function used to collect the information on all lucene indexes in
- * the entire Cache.
+ * The LuceneCreateIndexFunction class is a function used to create Lucene indexes.
  * </p>
  * @see Cache
  * @see com.gemstone.gemfire.cache.execute.Function

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneCreateIndexFunction.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneCreateIndexFunction.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gemstone.gemfire.cache.lucene.internal.cli.functions;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.gemstone.gemfire.cache.Cache;
+import com.gemstone.gemfire.cache.CacheFactory;
+import com.gemstone.gemfire.cache.execute.FunctionAdapter;
+import com.gemstone.gemfire.cache.execute.FunctionContext;
+import com.gemstone.gemfire.cache.lucene.LuceneIndex;
+import com.gemstone.gemfire.cache.lucene.LuceneService;
+import com.gemstone.gemfire.cache.lucene.LuceneServiceProvider;
+import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexImpl;
+import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneCliStrings;
+import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneIndexDetails;
+import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneIndexInfo;
+import com.gemstone.gemfire.internal.InternalEntity;
+import com.gemstone.gemfire.management.internal.cli.CliUtil;
+import com.gemstone.gemfire.management.internal.cli.functions.CliFunctionResult;
+import com.gemstone.gemfire.management.internal.cli.i18n.CliStrings;
+import com.gemstone.gemfire.management.internal.configuration.domain.XmlEntity;
+
+import org.apache.lucene.analysis.Analyzer;
+
+
+/**
+ * The LuceneListIndexFunction class is a function used to collect the information on all lucene indexes in
+ * the entire Cache.
+ * </p>
+ * @see Cache
+ * @see com.gemstone.gemfire.cache.execute.Function
+ * @see FunctionAdapter
+ * @see FunctionContext
+ * @see InternalEntity
+ * @see LuceneIndexDetails
+ */
+@SuppressWarnings("unused")
+public class LuceneCreateIndexFunction extends FunctionAdapter implements InternalEntity {
+
+  protected Cache getCache() {
+    return CacheFactory.getAnyInstance();
+  }
+
+  public String getId() {
+    return LuceneListIndexFunction.class.getName();
+  }
+
+  public void execute(final FunctionContext context) {
+    String memberId = null;
+    try {
+      final LuceneIndexInfo indexInfo = (LuceneIndexInfo) context.getArguments();
+      final Cache cache = getCache();
+      memberId = cache.getDistributedSystem().getDistributedMember().getId();
+      LuceneService service = LuceneServiceProvider.get(cache);
+
+      String[] fields = indexInfo.getSearchableFieldNames();
+      String[] analyzerName = indexInfo.getFieldAnalyzers();
+
+      if (analyzerName == null || analyzerName.length == 0) {
+        service.createIndex(indexInfo.getIndexName(), indexInfo.getRegionPath(), fields);
+      }
+      else {
+        Map<String, Analyzer> fieldAnalyzer = new HashMap<>();
+        for (int i = 0; i < fields.length; i++) {
+          Analyzer analyzer = toAnalyzer(analyzerName[i]);
+          fieldAnalyzer.put(fields[i], analyzer);
+        }
+        service.createIndex(indexInfo.getIndexName(), indexInfo.getRegionPath(), fieldAnalyzer);
+      }
+
+      //TODO - update cluster configuration by returning a valid XmlEntity
+      XmlEntity xmlEntity = null;
+      context.getResultSender().lastResult(new CliFunctionResult(memberId, xmlEntity));
+    }
+    catch (Exception e) {
+      String exceptionMessage = CliStrings.format(CliStrings.EXCEPTION_CLASS_AND_MESSAGE, e.getClass().getName(),
+        e.getMessage());
+      context.getResultSender().lastResult(new CliFunctionResult(memberId, e, e.getMessage()));
+    }
+  }
+
+  private Analyzer toAnalyzer(final String className)
+  {
+    Class<? extends Analyzer> clazz = CliUtil.forName(className, LuceneCliStrings.LUCENE_CREATE_INDEX__ANALYZER);
+    return CliUtil.newInstance(clazz, LuceneCliStrings.LUCENE_CREATE_INDEX__ANALYZER);
+  }
+
+}

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneDescribeIndexFunction.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneDescribeIndexFunction.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gemstone.gemfire.cache.lucene.internal.cli.functions;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.gemstone.gemfire.cache.Cache;
+import com.gemstone.gemfire.cache.CacheFactory;
+import com.gemstone.gemfire.cache.execute.FunctionAdapter;
+import com.gemstone.gemfire.cache.execute.FunctionContext;
+import com.gemstone.gemfire.cache.lucene.LuceneIndex;
+import com.gemstone.gemfire.cache.lucene.LuceneService;
+import com.gemstone.gemfire.cache.lucene.LuceneServiceProvider;
+import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexImpl;
+import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneIndexDetails;
+import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneIndexInfo;
+import com.gemstone.gemfire.internal.InternalEntity;
+
+/**
+ * The LuceneDescribeIndexFunction class is a function used to collect the information on a particular lucene index.
+ * </p>
+ * @see Cache
+ * @see com.gemstone.gemfire.cache.execute.Function
+ * @see FunctionAdapter
+ * @see FunctionContext
+ * @see InternalEntity
+ * @see LuceneIndexDetails
+ * @see LuceneIndexInfo
+ */
+@SuppressWarnings("unused")
+public class LuceneDescribeIndexFunction extends FunctionAdapter implements InternalEntity {
+
+  protected Cache getCache() {
+    return CacheFactory.getAnyInstance();
+  }
+
+  public String getId() {
+    return LuceneDescribeIndexFunction.class.getName();
+  }
+
+  public void execute(final FunctionContext context) {
+    LuceneIndexDetails result = null;
+    final Cache cache = getCache();
+    final LuceneIndexInfo indexInfo = (LuceneIndexInfo) context.getArguments();
+    LuceneService service = LuceneServiceProvider.get(cache);
+    LuceneIndex index = service.getIndex(indexInfo.getIndexName(), indexInfo.getRegionPath());
+    if (index != null) {
+      result = new LuceneIndexDetails((LuceneIndexImpl) index);
+    }
+    context.getResultSender().lastResult(result);
+  }
+}

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneListIndexFunction.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneListIndexFunction.java
@@ -54,18 +54,13 @@ public class LuceneListIndexFunction extends FunctionAdapter implements Internal
   }
 
   public void execute(final FunctionContext context) {
-    try {
-      final Set<LuceneIndexDetails> indexDetailsSet = new HashSet<>();
-      final Cache cache = getCache();
-      LuceneService service = LuceneServiceProvider.get(cache);
-      for (LuceneIndex index:service.getAllIndexes()) {
-        indexDetailsSet.add(new LuceneIndexDetails((LuceneIndexImpl) index));
-      }
-      context.getResultSender().lastResult(indexDetailsSet);
+    final Set<LuceneIndexDetails> indexDetailsSet = new HashSet<>();
+    final Cache cache = getCache();
+    LuceneService service = LuceneServiceProvider.get(cache);
+    for (LuceneIndex index : service.getAllIndexes()) {
+      indexDetailsSet.add(new LuceneIndexDetails((LuceneIndexImpl) index));
     }
-    catch (Exception e) {
-      context.getResultSender().sendException(e);
-    }
+    context.getResultSender().lastResult(indexDetailsSet);
   }
 
 }

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneListIndexFunction.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneListIndexFunction.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gemstone.gemfire.cache.lucene.internal.cli.functions;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.gemstone.gemfire.cache.Cache;
+import com.gemstone.gemfire.cache.CacheFactory;
+import com.gemstone.gemfire.cache.execute.FunctionAdapter;
+import com.gemstone.gemfire.cache.execute.FunctionContext;
+import com.gemstone.gemfire.cache.lucene.LuceneIndex;
+import com.gemstone.gemfire.cache.lucene.LuceneService;
+import com.gemstone.gemfire.cache.lucene.LuceneServiceProvider;
+import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexImpl;
+import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneIndexDetails;
+import com.gemstone.gemfire.internal.InternalEntity;
+
+/**
+ * The LuceneListIndexFunction class is a function used to collect the information on all lucene indexes in
+ * the entire Cache.
+ * </p>
+ * @see Cache
+ * @see com.gemstone.gemfire.cache.execute.Function
+ * @see FunctionAdapter
+ * @see FunctionContext
+ * @see InternalEntity
+ * @see LuceneIndexDetails
+ */
+@SuppressWarnings("unused")
+public class LuceneListIndexFunction extends FunctionAdapter implements InternalEntity {
+
+  protected Cache getCache() {
+    return CacheFactory.getAnyInstance();
+  }
+
+  public String getId() {
+    return LuceneListIndexFunction.class.getName();
+  }
+
+  public void execute(final FunctionContext context) {
+    try {
+      final Set<LuceneIndexDetails> indexDetailsSet = new HashSet<>();
+      final Cache cache = getCache();
+      LuceneService service = LuceneServiceProvider.get(cache);
+      for (LuceneIndex index:service.getAllIndexes()) {
+        indexDetailsSet.add(new LuceneIndexDetails((LuceneIndexImpl) index));
+      }
+      context.getResultSender().lastResult(indexDetailsSet);
+    }
+    catch (Exception e) {
+      context.getResultSender().sendException(e);
+    }
+  }
+
+}

--- a/geode-lucene/src/main/resources/META-INF/services/org.springframework.shell.core.CommandMarker
+++ b/geode-lucene/src/main/resources/META-INF/services/org.springframework.shell.core.CommandMarker
@@ -1,0 +1,2 @@
+# Lucene Extensions command
+com.gemstone.gemfire.cache.lucene.internal.cli.LuceneIndexCommands

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
@@ -61,7 +61,6 @@ public class LuceneIndexCommandsDUnitTest extends CliCommandTestBase {
     final VM vm1 = Host.getHost(0).getVM(1);
 
     createIndex(vm1);
-
     CommandManager.getInstance().add(LuceneIndexCommands.class.newInstance());
 
     CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_LIST_INDEX);

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
@@ -57,7 +57,21 @@ public class LuceneIndexCommandsDUnitTest extends CliCommandTestBase {
   }
 
   @Test
-  public void listIndexShouldReturnExistingIndex() throws Exception {
+  public void listIndexShouldReturnExistingIndexWithStats() throws Exception {
+    final VM vm1 = Host.getHost(0).getVM(1);
+
+    createIndex(vm1);
+    CommandManager.getInstance().add(LuceneIndexCommands.class.newInstance());
+
+    CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_LIST_INDEX);
+    csb.addOption(LuceneCliStrings.LUCENE_LIST_INDEX__STATS,"true");
+    String resultAsString = executeCommandAndLogResult(csb);
+    assertTrue(resultAsString.contains(INDEX_NAME));
+    assertTrue(resultAsString.contains("Documents"));
+  }
+
+  @Test
+  public void listIndexShouldReturnExistingIndexWithoutStats() throws Exception {
     final VM vm1 = Host.getHost(0).getVM(1);
 
     createIndex(vm1);
@@ -66,6 +80,18 @@ public class LuceneIndexCommandsDUnitTest extends CliCommandTestBase {
     CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_LIST_INDEX);
     String resultAsString = executeCommandAndLogResult(csb);
     assertTrue(resultAsString.contains(INDEX_NAME));
+    assertFalse(resultAsString.contains("Documents"));
+  }
+
+  @Test
+  public void listIndexWhenNoExistingIndexShouldReturnNoIndex() throws Exception {
+    final VM vm1 = Host.getHost(0).getVM(1);
+
+    CommandManager.getInstance().add(LuceneIndexCommands.class.newInstance());
+
+    CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_LIST_INDEX);
+    String resultAsString = executeCommandAndLogResult(csb);
+    assertTrue(resultAsString.contains("No lucene indexes found"));
   }
 
   @Test

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
@@ -1,40 +1,78 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.gemstone.gemfire.cache.lucene.internal.cli;
 
-import static com.gemstone.gemfire.test.dunit.LogWriterUtils.getLogWriter;
-import static org.junit.Assert.*;
-
-import com.gemstone.gemfire.management.cli.Result;
+import com.gemstone.gemfire.cache.*;
+import com.gemstone.gemfire.cache.lucene.LuceneService;
+import com.gemstone.gemfire.cache.lucene.LuceneServiceProvider;
+import com.gemstone.gemfire.management.cli.Result.Status;
+import com.gemstone.gemfire.management.internal.cli.CommandManager;
 import com.gemstone.gemfire.management.internal.cli.commands.CliCommandTestBase;
-import com.gemstone.gemfire.management.internal.cli.i18n.CliStrings;
+import com.gemstone.gemfire.management.internal.cli.result.CommandResult;
+import com.gemstone.gemfire.management.internal.cli.util.CommandStringBuilder;
+import com.gemstone.gemfire.test.dunit.*;
+import com.gemstone.gemfire.test.junit.categories.DistributedTest;
 
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+import static com.gemstone.gemfire.cache.lucene.test.LuceneTestUtilities.*;
+import static com.gemstone.gemfire.test.dunit.Assert.*;
+
+@Category(DistributedTest.class)
 public class LuceneIndexCommandsDUnitTest extends CliCommandTestBase {
 
   @Test
   public void testListIndex() throws Exception {
-    final Result result = executeCommand(LuceneCliStrings.LIST_INDEX);
+    setupSystem();
+    CommandManager.getInstance().add(LuceneIndexCommands.class.newInstance());
 
-    assertNotNull(result);
-    assertEquals(Result.Status.OK, result.getStatus());
+    CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_LIST_INDEX);
+    String commandString = csb.toString();
+    writeToLog("Command String :\n ", commandString);
+    CommandResult commandResult = executeCommand(commandString);
+    String resultAsString = commandResultToString(commandResult);
+    writeToLog("Result String :\n ", resultAsString);
+    assertEquals(Status.OK, commandResult.getStatus());
+    assertTrue(resultAsString.contains(INDEX_NAME));
+  }
+
+  private void writeToLog(String text, String resultAsString) {
+    System.out.println(getTestMethodName() + " : ");
+    System.out.println(resultAsString);
+  }
+
+  protected void initDataStore(SerializableRunnableIF createIndex) throws Exception {
+    createIndex.run();
+    getCache().createRegionFactory(RegionShortcut.PARTITION).create(REGION_NAME);
+  }
+
+  private void setupSystem() {
+    disconnectAllFromDS();
+    setUpJmxManagerOnVm0ThenConnect(null);
+
+    final VM manager = Host.getHost(0).getVM(0);
+    final VM vm1 = Host.getHost(0).getVM(1);
+
+    SerializableRunnableIF createIndex = () -> {
+      LuceneService luceneService = LuceneServiceProvider.get(getCache());
+      luceneService.createIndex(INDEX_NAME, REGION_NAME, "text");
+    };
+    vm1.invoke(()->initDataStore(createIndex));
   }
 
 }

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
@@ -17,8 +17,10 @@
 package com.gemstone.gemfire.cache.lucene.internal.cli;
 
 import com.gemstone.gemfire.cache.*;
+import com.gemstone.gemfire.cache.lucene.LuceneIndex;
 import com.gemstone.gemfire.cache.lucene.LuceneService;
 import com.gemstone.gemfire.cache.lucene.LuceneServiceProvider;
+import com.gemstone.gemfire.distributed.ConfigurationProperties;
 import com.gemstone.gemfire.management.cli.Result.Status;
 import com.gemstone.gemfire.management.internal.cli.CommandManager;
 import com.gemstone.gemfire.management.internal.cli.commands.CliCommandTestBase;
@@ -26,63 +28,171 @@ import com.gemstone.gemfire.management.internal.cli.result.CommandResult;
 import com.gemstone.gemfire.management.internal.cli.util.CommandStringBuilder;
 import com.gemstone.gemfire.test.dunit.*;
 import com.gemstone.gemfire.test.junit.categories.DistributedTest;
+import com.sun.org.apache.regexp.internal.RE;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import static com.gemstone.gemfire.cache.lucene.test.LuceneTestUtilities.*;
 import static com.gemstone.gemfire.test.dunit.Assert.*;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
 
 @Category(DistributedTest.class)
 public class LuceneIndexCommandsDUnitTest extends CliCommandTestBase {
 
+  @Before
+  public void createJMXManager() {
+    disconnectAllFromDS();
+    setUpJmxManagerOnVm0ThenConnect(null);
+  }
+
   @Test
-  public void testListIndex() throws Exception {
-    setupSystem();
+  public void listIndexShouldReturnExistingIndex() throws Exception {
+    final VM vm1 = Host.getHost(0).getVM(1);
+
+    createIndex(vm1);
+
     CommandManager.getInstance().add(LuceneIndexCommands.class.newInstance());
 
     CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_LIST_INDEX);
+    String resultAsString = executeCommandAndLogResult(csb);
+    assertTrue(resultAsString.contains(INDEX_NAME));
+  }
+
+  @Test
+  public void createIndexShouldCreateANewIndex() throws Exception {
+    final VM vm1 = Host.getHost(0).getVM(1);
+    vm1.invoke(() -> {getCache();});
+
+    CommandManager.getInstance().add(LuceneIndexCommands.class.newInstance());
+
+    CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_CREATE_INDEX);
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__NAME,INDEX_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__REGION,REGION_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__FIELD,"field1,field2,field3");
+
+    String resultAsString = executeCommandAndLogResult(csb);
+
+    vm1.invoke(() -> {
+      LuceneService luceneService = LuceneServiceProvider.get(getCache());
+      createRegion();
+      final LuceneIndex index = luceneService.getIndex(INDEX_NAME, REGION_NAME);
+      assertArrayEquals(new String[] {"field1", "field2", "field3"}, index.getFieldNames());
+    });
+  }
+
+  @Test
+  public void createIndexWithAnalyzersShouldCreateANewIndex() throws Exception {
+    final VM vm1 = Host.getHost(0).getVM(1);
+    vm1.invoke(() -> {getCache();});
+
+    CommandManager.getInstance().add(LuceneIndexCommands.class.newInstance());
+
+    List<String> analyzerNames = new ArrayList<>();
+    analyzerNames.add(StandardAnalyzer.class.getCanonicalName());
+    analyzerNames.add(KeywordAnalyzer.class.getCanonicalName());
+    analyzerNames.add(StandardAnalyzer.class.getCanonicalName());
+
+
+    CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_CREATE_INDEX);
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__NAME,INDEX_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__REGION,REGION_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__FIELD,"field1,field2,field3");
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__ANALYZER,String.join(",",analyzerNames));
+
+    String resultAsString = executeCommandAndLogResult(csb);
+
+    vm1.invoke(() -> {
+      LuceneService luceneService = LuceneServiceProvider.get(getCache());
+      createRegion();
+      final LuceneIndex index = luceneService.getIndex(INDEX_NAME, REGION_NAME);
+      final Map<String, Analyzer> fieldAnalyzers = index.getFieldAnalyzers();
+      assertEquals(StandardAnalyzer.class, fieldAnalyzers.get("field1").getClass());
+      assertEquals(KeywordAnalyzer.class, fieldAnalyzers.get("field2").getClass());
+      assertEquals(StandardAnalyzer.class, fieldAnalyzers.get("field3").getClass());
+    });
+  }
+
+  @Test
+  public void createIndexOnGroupShouldCreateANewIndexOnGroup() throws Exception {
+    final VM vm1 = Host.getHost(0).getVM(1);
+    final VM vm2 = Host.getHost(0).getVM(2);
+    vm1.invoke(() -> {
+      getCache();
+    });
+    vm2.invoke(() -> {
+      Properties props = new Properties();
+      props.setProperty(ConfigurationProperties.GROUPS, "group1");
+      getSystem(props);
+      getCache();
+    });
+
+
+    CommandManager.getInstance().add(LuceneIndexCommands.class.newInstance());
+
+    CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_CREATE_INDEX);
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__NAME,INDEX_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__REGION,REGION_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__FIELD,"field1,field2,field3");
+    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__GROUP,"group1");
+    String resultAsString = executeCommandAndLogResult(csb);
+
+    vm2.invoke(() -> {
+      LuceneService luceneService = LuceneServiceProvider.get(getCache());
+      createRegion();
+      final LuceneIndex index = luceneService.getIndex(INDEX_NAME, REGION_NAME);
+      assertArrayEquals(new String[] {"field1", "field2", "field3"}, index.getFieldNames());
+    });
+
+    vm1.invoke(() -> {
+      LuceneService luceneService = LuceneServiceProvider.get(getCache());
+      try {
+        createRegion();
+        fail("Should have thrown an exception due to the missing index");
+      } catch(IllegalStateException expected) {
+
+      }
+    });
+  }
+
+  private void createRegion() {
+    getCache().createRegionFactory(RegionShortcut.PARTITION).create(REGION_NAME);
+  }
+
+  private String executeCommandAndLogResult(final CommandStringBuilder csb) {
     String commandString = csb.toString();
     writeToLog("Command String :\n ", commandString);
     CommandResult commandResult = executeCommand(commandString);
     String resultAsString = commandResultToString(commandResult);
     writeToLog("Result String :\n ", resultAsString);
-    assertEquals(Status.OK, commandResult.getStatus());
-    assertTrue(resultAsString.contains(INDEX_NAME));
+    assertEquals("Command failed\n" + resultAsString, Status.OK, commandResult.getStatus());
+    return resultAsString;
   }
 
-  private void writeToLog(String text, String resultAsString) {
-    System.out.println(getTestMethodName() + " : ");
-    System.out.println(resultAsString);
-  }
-
-  protected void initDataStore(SerializableRunnableIF createIndex) throws Exception {
-    createIndex.run();
-    getCache().createRegionFactory(RegionShortcut.PARTITION).create(REGION_NAME);
-  }
-
-  private void setupSystem() {
-    disconnectAllFromDS();
-    setUpJmxManagerOnVm0ThenConnect(null);
-
-    final VM manager = Host.getHost(0).getVM(0);
-    final VM vm1 = Host.getHost(0).getVM(1);
-
-    SerializableRunnableIF createIndex = () -> {
+  private void createIndex(final VM vm1) {
+    vm1.invoke(() -> {
       LuceneService luceneService = LuceneServiceProvider.get(getCache());
       Map<String, Analyzer> fieldAnalyzers = new HashMap();
       fieldAnalyzers.put("field1", new StandardAnalyzer());
       fieldAnalyzers.put("field2", new KeywordAnalyzer());
       fieldAnalyzers.put("field3", null);
       luceneService.createIndex(INDEX_NAME, REGION_NAME, fieldAnalyzers);
-    };
-    vm1.invoke(()->initDataStore(createIndex));
+      createRegion();
+    });
   }
 
+  private void writeToLog(String text, String resultAsString) {
+    System.out.println(text + ": " + getTestMethodName() + " : ");
+    System.out.println(text + ":" + resultAsString);
+  }
 }

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.gemstone.gemfire.cache.lucene.internal.cli;
+
+import static com.gemstone.gemfire.test.dunit.LogWriterUtils.getLogWriter;
+import static org.junit.Assert.*;
+
+import com.gemstone.gemfire.management.cli.Result;
+import com.gemstone.gemfire.management.internal.cli.commands.CliCommandTestBase;
+import com.gemstone.gemfire.management.internal.cli.i18n.CliStrings;
+
+import org.junit.Test;
+
+public class LuceneIndexCommandsDUnitTest extends CliCommandTestBase {
+
+  @Test
+  public void testListIndex() throws Exception {
+    final Result result = executeCommand(LuceneCliStrings.LIST_INDEX);
+
+    assertNotNull(result);
+    assertEquals(Result.Status.OK, result.getStatus());
+  }
+
+}

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
@@ -28,7 +28,6 @@ import com.gemstone.gemfire.management.internal.cli.result.CommandResult;
 import com.gemstone.gemfire.management.internal.cli.util.CommandStringBuilder;
 import com.gemstone.gemfire.test.dunit.*;
 import com.gemstone.gemfire.test.junit.categories.DistributedTest;
-import com.sun.org.apache.regexp.internal.RE;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
@@ -45,7 +44,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.stream.Collectors;
 
 @Category(DistributedTest.class)
 public class LuceneIndexCommandsDUnitTest extends CliCommandTestBase {
@@ -102,8 +100,8 @@ public class LuceneIndexCommandsDUnitTest extends CliCommandTestBase {
     CommandManager.getInstance().add(LuceneIndexCommands.class.newInstance());
 
     CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_CREATE_INDEX);
-    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__NAME,INDEX_NAME);
-    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__REGION,REGION_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE__INDEX_NAME,INDEX_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE__REGION_PATH,REGION_NAME);
     csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__FIELD,"field1,field2,field3");
 
     String resultAsString = executeCommandAndLogResult(csb);
@@ -130,8 +128,8 @@ public class LuceneIndexCommandsDUnitTest extends CliCommandTestBase {
 
 
     CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_CREATE_INDEX);
-    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__NAME,INDEX_NAME);
-    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__REGION,REGION_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE__INDEX_NAME,INDEX_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE__REGION_PATH,REGION_NAME);
     csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__FIELD,"field1,field2,field3");
     csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__ANALYZER,String.join(",",analyzerNames));
 
@@ -162,12 +160,11 @@ public class LuceneIndexCommandsDUnitTest extends CliCommandTestBase {
       getCache();
     });
 
-
     CommandManager.getInstance().add(LuceneIndexCommands.class.newInstance());
 
     CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_CREATE_INDEX);
-    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__NAME,INDEX_NAME);
-    csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__REGION,REGION_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE__INDEX_NAME,INDEX_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE__REGION_PATH,REGION_NAME);
     csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__FIELD,"field1,field2,field3");
     csb.addOption(LuceneCliStrings.LUCENE_CREATE_INDEX__GROUP,"group1");
     String resultAsString = executeCommandAndLogResult(csb);
@@ -188,6 +185,35 @@ public class LuceneIndexCommandsDUnitTest extends CliCommandTestBase {
 
       }
     });
+  }
+
+  @Test
+  public void describeIndexShouldReturnExistingIndex() throws Exception {
+    final VM vm1 = Host.getHost(0).getVM(1);
+
+    createIndex(vm1);
+    CommandManager.getInstance().add(LuceneIndexCommands.class.newInstance());
+
+    CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_DESCRIBE_INDEX);
+    csb.addOption(LuceneCliStrings.LUCENE__INDEX_NAME,INDEX_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE__REGION_PATH,REGION_NAME);
+    String resultAsString = executeCommandAndLogResult(csb);
+    assertTrue(resultAsString.contains(INDEX_NAME));
+  }
+
+  @Test
+  public void describeIndexShouldNotReturnResultWhenIndexNotFound() throws Exception {
+    final VM vm1 = Host.getHost(0).getVM(1);
+
+    createIndex(vm1);
+    CommandManager.getInstance().add(LuceneIndexCommands.class.newInstance());
+
+    CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_DESCRIBE_INDEX);
+    csb.addOption(LuceneCliStrings.LUCENE__INDEX_NAME,"notAnIndex");
+    csb.addOption(LuceneCliStrings.LUCENE__REGION_PATH,REGION_NAME);
+    String resultAsString = executeCommandAndLogResult(csb);
+
+    assertTrue(resultAsString.contains("No lucene indexes found"));
   }
 
   private void createRegion() {

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
@@ -27,11 +27,17 @@ import com.gemstone.gemfire.management.internal.cli.util.CommandStringBuilder;
 import com.gemstone.gemfire.test.dunit.*;
 import com.gemstone.gemfire.test.junit.categories.DistributedTest;
 
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.core.KeywordAnalyzer;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import static com.gemstone.gemfire.cache.lucene.test.LuceneTestUtilities.*;
 import static com.gemstone.gemfire.test.dunit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Category(DistributedTest.class)
 public class LuceneIndexCommandsDUnitTest extends CliCommandTestBase {
@@ -70,7 +76,11 @@ public class LuceneIndexCommandsDUnitTest extends CliCommandTestBase {
 
     SerializableRunnableIF createIndex = () -> {
       LuceneService luceneService = LuceneServiceProvider.get(getCache());
-      luceneService.createIndex(INDEX_NAME, REGION_NAME, "text");
+      Map<String, Analyzer> fieldAnalyzers = new HashMap();
+      fieldAnalyzers.put("field1", new StandardAnalyzer());
+      fieldAnalyzers.put("field2", new KeywordAnalyzer());
+      fieldAnalyzers.put("field3", null);
+      luceneService.createIndex(INDEX_NAME, REGION_NAME, fieldAnalyzers);
     };
     vm1.invoke(()->initDataStore(createIndex));
   }

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsJUnitTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsJUnitTest.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gemstone.gemfire.cache.lucene.internal.cli;
+import static com.gemstone.gemfire.internal.lang.StringUtils.trim;
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.jmock.Expectations;
+import org.jmock.Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import com.gemstone.gemfire.cache.Cache;
+import com.gemstone.gemfire.cache.execute.Execution;
+import com.gemstone.gemfire.cache.execute.FunctionInvocationTargetException;
+import com.gemstone.gemfire.cache.execute.ResultCollector;
+import com.gemstone.gemfire.cache.lucene.internal.cli.functions.LuceneListIndexFunction;
+import com.gemstone.gemfire.distributed.DistributedMember;
+import com.gemstone.gemfire.internal.cache.execute.AbstractExecution;
+import com.gemstone.gemfire.internal.util.CollectionUtils;
+import com.gemstone.gemfire.management.internal.cli.functions.ListIndexFunction;
+import com.gemstone.gemfire.test.junit.categories.UnitTest;
+
+/**
+ * The LuceneIndexCommandsJUnitTest class is a test suite of test cases testing the contract and functionality of the
+ * LuceneIndexCommands class.
+ * </p>
+ * @see LuceneIndexCommands
+ * @see LuceneIndexDetails
+ * @see com.gemstone.gemfire.cache.lucene.internal.cli.functions.LuceneListIndexFunction
+ * @see org.jmock.Expectations
+ * @see org.jmock.Mockery
+ * @see org.jmock.lib.legacy.ClassImposteriser
+ * @see org.junit.Assert
+ * @see org.junit.Test
+ * @since GemFire 7.0
+ */
+@Category(UnitTest.class)
+public class LuceneIndexCommandsJUnitTest {
+
+  private Mockery mockContext;
+
+  @Before
+  public void setup() {
+    mockContext = new Mockery() {{
+      setImposteriser(ClassImposteriser.INSTANCE);
+    }};
+  }
+
+  @After
+  public void tearDown() {
+    mockContext.assertIsSatisfied();
+    mockContext = null;
+  }
+
+  private LuceneIndexCommands createIndexCommands(final Cache cache, final Execution functionExecutor) {
+    return new LuceneTestIndexCommands(cache, functionExecutor);
+  }
+
+  private LuceneIndexDetails createIndexDetails(final String indexName, final String regionPath, final String[] searchableFields) {
+    return new LuceneIndexDetails(indexName, regionPath, searchableFields);
+  }
+
+  @Test
+  public void testGetIndexListing() {
+
+    final Cache mockCache = mockContext.mock(Cache.class, "Cache");
+    final AbstractExecution mockFunctionExecutor = mockContext.mock(AbstractExecution.class, "Function Executor");
+    final ResultCollector mockResultCollector = mockContext.mock(ResultCollector.class, "ResultCollector");
+    String[] searchableFields={"field1","field2","field3"};
+    final LuceneIndexDetails indexDetails1 = createIndexDetails("memberFive", "/Employees", searchableFields);
+    final LuceneIndexDetails indexDetails2 = createIndexDetails("memberSix", "/Employees", searchableFields);
+    final LuceneIndexDetails indexDetails3 = createIndexDetails("memberTen", "/Employees", searchableFields);
+
+    final List<LuceneIndexDetails> expectedIndexDetails = new ArrayList<>(3);
+    expectedIndexDetails.add(indexDetails1);
+    expectedIndexDetails.add(indexDetails2);
+    expectedIndexDetails.add(indexDetails3);
+
+    final List<Set<LuceneIndexDetails>> results = new ArrayList<Set<LuceneIndexDetails>>();
+
+    results.add(CollectionUtils.asSet(indexDetails2, indexDetails1,indexDetails3));
+
+    mockContext.checking(new Expectations() {{
+      oneOf(mockFunctionExecutor).setIgnoreDepartedMembers(with(equal(true)));
+      oneOf(mockFunctionExecutor).execute(with(aNonNull(LuceneListIndexFunction.class)));
+      will(returnValue(mockResultCollector));
+      oneOf(mockResultCollector).getResult();
+      will(returnValue(results));
+    }});
+
+    final LuceneIndexCommands commands = createIndexCommands(mockCache, mockFunctionExecutor);
+
+    final List<LuceneIndexDetails> actualIndexDetails = commands.getIndexListing();
+
+    assertNotNull(actualIndexDetails);
+    assertEquals(expectedIndexDetails, actualIndexDetails);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testGetIndexListingThrowsRuntimeException() {
+    final Cache mockCache = mockContext.mock(Cache.class, "Cache");
+
+    final Execution mockFunctionExecutor = mockContext.mock(Execution.class, "Function Executor");
+
+    mockContext.checking(new Expectations() {{
+      oneOf(mockFunctionExecutor).execute(with(aNonNull(LuceneListIndexFunction.class)));
+      will(throwException(new RuntimeException("expected")));
+    }});
+
+    final LuceneIndexCommands commands = createIndexCommands(mockCache, mockFunctionExecutor);
+
+    try {
+      commands.getIndexListing();
+    }
+    catch (RuntimeException expected) {
+      assertEquals("expected", expected.getMessage());
+      throw expected;
+    }
+  }
+
+  @Test
+  public void testGetIndexListingReturnsFunctionInvocationTargetExceptionInResults() {
+    final Cache mockCache = mockContext.mock(Cache.class, "Cache");
+
+    final AbstractExecution mockFunctionExecutor = mockContext.mock(AbstractExecution.class, "Function Executor");
+
+    final ResultCollector mockResultCollector = mockContext.mock(ResultCollector.class, "ResultCollector");
+    String[] searchableFields={"field1","field2","field3"};
+    final LuceneIndexDetails indexDetails = createIndexDetails("memberOne", "/Employees",searchableFields );
+
+    final List<LuceneIndexDetails> expectedIndexDetails = new ArrayList<>();
+    expectedIndexDetails.add(indexDetails);
+
+    final List<Object> results = new ArrayList<Object>(2);
+
+    results.add(CollectionUtils.asSet(indexDetails));
+    results.add(new FunctionInvocationTargetException("expected"));
+
+    mockContext.checking(new Expectations() {{
+      oneOf(mockFunctionExecutor).setIgnoreDepartedMembers(with(equal(true)));
+      oneOf(mockFunctionExecutor).execute(with(aNonNull(LuceneListIndexFunction.class)));
+      will(returnValue(mockResultCollector));
+      oneOf(mockResultCollector).getResult();
+      will(returnValue(results));
+    }});
+
+    final LuceneIndexCommands commands = createIndexCommands(mockCache, mockFunctionExecutor);
+
+    final List<LuceneIndexDetails> actualIndexDetails = commands.getIndexListing();
+
+    assertNotNull(actualIndexDetails);
+    assertEquals(expectedIndexDetails, actualIndexDetails);
+  }
+
+  private static class LuceneTestIndexCommands extends LuceneIndexCommands {
+
+    private final Cache cache;
+    private final Execution functionExecutor;
+
+    protected LuceneTestIndexCommands(final Cache cache, final Execution functionExecutor) {
+      assert cache != null : "The Cache cannot be null!";
+      assert functionExecutor != null : "The function executor cannot be null!";
+      this.cache = cache;
+      this.functionExecutor = functionExecutor;
+    }
+
+    @Override
+    protected Cache getCache() {
+      return this.cache;
+    }
+
+    @Override
+    protected Set<DistributedMember> getMembers(final Cache cache) {
+      assertSame(getCache(), cache);
+      return Collections.emptySet();
+    }
+
+    @Override
+    protected Execution getMembersFunctionExecutor(final Set<DistributedMember> members) {
+      Assert.assertNotNull(members);
+      return functionExecutor;
+    }
+  }
+
+}

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneCreateIndexFunctionJUnitTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneCreateIndexFunctionJUnitTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gemstone.gemfire.cache.lucene.internal.cli.functions;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.core.KeywordAnalyzer;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.ArgumentCaptor;
+import com.gemstone.gemfire.cache.execute.FunctionContext;
+import com.gemstone.gemfire.cache.execute.ResultSender;
+import com.gemstone.gemfire.cache.lucene.internal.InternalLuceneService;
+import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneIndexInfo;
+import com.gemstone.gemfire.distributed.DistributedSystem;
+import com.gemstone.gemfire.internal.cache.GemFireCacheImpl;
+import com.gemstone.gemfire.management.internal.cli.functions.CliFunctionResult;
+import com.gemstone.gemfire.management.internal.configuration.domain.XmlEntity;
+import com.gemstone.gemfire.test.fake.Fakes;
+import com.gemstone.gemfire.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+
+public class LuceneCreateIndexFunctionJUnitTest {
+  
+  private InternalLuceneService service;
+  private GemFireCacheImpl cache;
+  String member;
+  FunctionContext context;
+  ResultSender resultSender;
+  CliFunctionResult expectedResult;
+  
+  @Before
+  public void prepare() {
+    cache = Fakes.cache();
+    DistributedSystem ds = Fakes.distributedSystem();
+    member = ds.getDistributedMember().getId();
+    service = mock(InternalLuceneService.class);
+    when(cache.getService(InternalLuceneService.class)).thenReturn(service);
+    doNothing().when(service).createIndex(anyString(), anyString(), anyMap());
+    
+    context = mock(FunctionContext.class);
+    resultSender = mock(ResultSender.class);
+    when(context.getResultSender()).thenReturn(resultSender);
+
+    XmlEntity xmlEntity = null;
+    expectedResult = new CliFunctionResult(member, xmlEntity);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testExecuteWithAnalyzer() throws Throwable {
+    List<String> analyzerNames = new ArrayList<>();
+    analyzerNames.add(StandardAnalyzer.class.getCanonicalName());
+    analyzerNames.add(KeywordAnalyzer.class.getCanonicalName());
+    analyzerNames.add(StandardAnalyzer.class.getCanonicalName());
+    String [] analyzers = new String[3];
+    analyzerNames.toArray(analyzers);
+    LuceneIndexInfo indexInfo = new LuceneIndexInfo("index1", "/region1", 
+        new String[] {"field1", "field2", "field3"}, analyzers);
+    when(context.getArguments()).thenReturn(indexInfo);
+
+    LuceneCreateIndexFunction function = new LuceneCreateIndexFunction();
+    function = spy(function);
+    doReturn(cache).when(function).getCache();
+    function.execute(context);
+    
+    ArgumentCaptor<Map> analyzersCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(service).createIndex(eq("index1"), eq("/region1"), analyzersCaptor.capture());
+    Map<String, Analyzer> analyzerPerField = analyzersCaptor.getValue();
+    assertEquals(3, analyzerPerField.size());
+    assertTrue(analyzerPerField.get("field1") instanceof StandardAnalyzer);
+    assertTrue(analyzerPerField.get("field2") instanceof KeywordAnalyzer);
+    assertTrue(analyzerPerField.get("field3") instanceof StandardAnalyzer);
+    
+    ArgumentCaptor<Set> resultCaptor  = ArgumentCaptor.forClass(Set.class);
+    verify(resultSender).lastResult(resultCaptor.capture());
+    CliFunctionResult result = (CliFunctionResult)resultCaptor.getValue();
+
+    assertEquals(expectedResult, result);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testExecuteWithoutAnalyzer() throws Throwable {
+    String fields[] = new String[] {"field1", "field2", "field3"};
+    LuceneIndexInfo indexInfo = new LuceneIndexInfo("index1", "/region1", fields, null);
+    when(context.getArguments()).thenReturn(indexInfo);
+
+    LuceneCreateIndexFunction function = new LuceneCreateIndexFunction();
+    function = spy(function);
+    doReturn(cache).when(function).getCache();
+    function.execute(context);
+    
+    verify(service).createIndex(eq("index1"), eq("/region1"), eq("field1"), eq("field2"), eq("field3"));
+
+    ArgumentCaptor<Set> resultCaptor  = ArgumentCaptor.forClass(Set.class);
+    verify(resultSender).lastResult(resultCaptor.capture());
+    CliFunctionResult result = (CliFunctionResult)resultCaptor.getValue();
+
+    assertEquals(expectedResult, result);
+  }
+}

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneDescribeIndexFunctionJUnitTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneDescribeIndexFunctionJUnitTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gemstone.gemfire.cache.lucene.internal.cli.functions;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import com.gemstone.gemfire.cache.execute.FunctionContext;
+import com.gemstone.gemfire.cache.execute.ResultSender;
+import com.gemstone.gemfire.cache.lucene.LuceneIndex;
+import com.gemstone.gemfire.cache.lucene.internal.InternalLuceneService;
+import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexImpl;
+import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneIndexDetails;
+import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneIndexInfo;
+import com.gemstone.gemfire.internal.cache.GemFireCacheImpl;
+import com.gemstone.gemfire.test.fake.Fakes;
+import com.gemstone.gemfire.test.junit.categories.UnitTest;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.core.KeywordAnalyzer;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+@Category(UnitTest.class)
+
+public class LuceneDescribeIndexFunctionJUnitTest {
+  
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testExecute() throws Throwable {
+    GemFireCacheImpl cache = Fakes.cache();
+    InternalLuceneService service = mock(InternalLuceneService.class);
+    when(cache.getService(InternalLuceneService.class)).thenReturn(service);
+    FunctionContext context = mock(FunctionContext.class);
+    ResultSender resultSender = mock(ResultSender.class);
+    LuceneIndexInfo indexInfo=getMockLuceneInfo("index1");
+    LuceneIndexImpl index1 = getMockLuceneIndex("index1");
+    LuceneDescribeIndexFunction function = spy(LuceneDescribeIndexFunction.class);
+
+    doReturn(indexInfo).when(context).getArguments();
+    doReturn(resultSender).when(context).getResultSender();
+    doReturn(cache).when(function).getCache();
+    when(service.getIndex(indexInfo.getIndexName(),indexInfo.getRegionPath())).thenReturn(index1);
+
+    function.execute(context);
+    ArgumentCaptor<LuceneIndexDetails> resultCaptor  = ArgumentCaptor.forClass(LuceneIndexDetails.class);
+    verify(resultSender).lastResult(resultCaptor.capture());
+    LuceneIndexDetails result = resultCaptor.getValue();
+    LuceneIndexDetails expected=new LuceneIndexDetails(index1);
+
+    assertEquals(expected.getIndexName(),result.getIndexName());
+    assertEquals(expected.getRegionPath(),result.getRegionPath());
+    assertEquals(expected.getIndexStats(),result.getIndexStats());
+    assertEquals(expected.getFieldAnalyzersString(),result.getFieldAnalyzersString());
+    assertEquals(expected.getSearchableFieldNamesString(),result.getSearchableFieldNamesString());
+  }
+
+  private LuceneIndexInfo getMockLuceneInfo(final String index1) {
+    LuceneIndexInfo mockInfo=mock(LuceneIndexInfo.class);
+    doReturn(index1).when(mockInfo).getIndexName();
+    doReturn("/region").when(mockInfo).getRegionPath();
+    return mockInfo;
+  }
+
+  private LuceneIndexImpl getMockLuceneIndex(final String indexName)
+  {
+    String[] searchableFields={"field1","field2"};
+    Map<String, Analyzer> fieldAnalyzers = new HashMap<>();
+    fieldAnalyzers.put("field1", new StandardAnalyzer());
+    fieldAnalyzers.put("field2", new KeywordAnalyzer());
+
+    LuceneIndexImpl index = mock(LuceneIndexImpl.class);
+    when(index.getName()).thenReturn(indexName);
+    when(index.getRegionPath()).thenReturn("/region");
+    when(index.getFieldNames()).thenReturn(searchableFields);
+    when(index.getFieldAnalyzers()).thenReturn(fieldAnalyzers);
+    return index;
+  }
+
+}

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneListIndexFunctionJUnitTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneListIndexFunctionJUnitTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gemstone.gemfire.cache.lucene.internal.cli.functions;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.core.KeywordAnalyzer;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import com.gemstone.gemfire.cache.execute.FunctionContext;
+import com.gemstone.gemfire.cache.execute.ResultSender;
+import com.gemstone.gemfire.cache.lucene.LuceneIndex;
+import com.gemstone.gemfire.cache.lucene.internal.InternalLuceneService;
+import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexImpl;
+import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneIndexDetails;
+import com.gemstone.gemfire.internal.cache.GemFireCacheImpl;
+import com.gemstone.gemfire.test.fake.Fakes;
+import com.gemstone.gemfire.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+
+public class LuceneListIndexFunctionJUnitTest {
+  
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testExecute() throws Throwable {
+    GemFireCacheImpl cache = Fakes.cache();
+    InternalLuceneService service = mock(InternalLuceneService.class);
+    when(cache.getService(InternalLuceneService.class)).thenReturn(service);
+    
+    FunctionContext context = mock(FunctionContext.class);
+    ResultSender resultSender = mock(ResultSender.class);
+    when(context.getResultSender()).thenReturn(resultSender);
+
+    LuceneIndexImpl index1 = getMockLuceneIndex("index1");
+    LuceneIndexImpl index2 = getMockLuceneIndex("index2");
+
+    TreeSet expectedResult = new TreeSet();
+    expectedResult.add(new LuceneIndexDetails(index1));
+    expectedResult.add(new LuceneIndexDetails(index2));
+
+    ArrayList<LuceneIndex> allIndexes = new ArrayList();
+    allIndexes.add(index1);
+    allIndexes.add(index2);
+    when(service.getAllIndexes()).thenReturn(allIndexes);
+    
+    LuceneListIndexFunction function = new LuceneListIndexFunction();
+    function = spy(function);
+    Mockito.doReturn(cache).when(function).getCache();
+    function.execute(context);
+    
+    ArgumentCaptor<Set> resultCaptor  = ArgumentCaptor.forClass(Set.class);
+    verify(resultSender).lastResult(resultCaptor.capture());
+    Set<String> result = resultCaptor.getValue();
+
+    assertEquals(2, result.size());
+    assertEquals(expectedResult, result);
+  }
+
+  private LuceneIndexImpl getMockLuceneIndex(final String indexName)
+  {
+    String[] searchableFields={"field1","field2"};
+    Map<String, Analyzer> fieldAnalyzers = new HashMap<>();
+    fieldAnalyzers.put("field1", new StandardAnalyzer());
+    fieldAnalyzers.put("field2", new KeywordAnalyzer());
+
+    LuceneIndexImpl index = mock(LuceneIndexImpl.class);
+    when(index.getName()).thenReturn(indexName);
+    when(index.getRegionPath()).thenReturn("/region");
+    when(index.getFieldNames()).thenReturn(searchableFields);
+    when(index.getFieldAnalyzers()).thenReturn(fieldAnalyzers);
+    return index;
+  }
+
+}


### PR DESCRIPTION
- Added stats option to the list lucene index gfsh command.
- Added describe lucene index gfsh command that takes the index name and region as arguments and displays information about the lucene index (fields, analyzers and stats).
- Added junit and dunit tests for the above mentioned functionalities.