### PR TITLE
GEODE-11:Gfsh command for lucene query

### DIFF
--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneCliStrings.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneCliStrings.java
@@ -57,6 +57,16 @@ public class LuceneCliStrings {
   public static final String LUCENE_DESCRIBE_INDEX__NAME__HELP = "Name of the lucene index to describe.";
   public static final String LUCENE_DESCRIBE_INDEX__REGION_HELP = "Name/Path of the region where the lucene index to be described exists.";
 
-
-
+  
+  //Search lucene index commands
+  public static final String LUCENE_SEARCH_INDEX = "lucene search";
+  public static final String LUCENE_SEARCH_INDEX__HELP = "Search lucene index";
+  public static final String LUCENE_SEARCH_INDEX__ERROR_MESSAGE = "An error occurred while searching lucene index across the Geode cluster: %1$s";
+  public static final String LUCENE_SEARCH_INDEX__NAME__HELP = "Name of the lucene index to search.";
+  public static final String LUCENE_SEARCH_INDEX__REGION_HELP = "Name/Path of the region where the lucene index exists.";
+  public static final String LUCENE_SEARCH_INDEX__QUERY_STRING="queryStrings";
+  public static final String LUCENE_SEARCH_INDEX__QUERY_STRING__HELP="Query string to search the lucene index";
+  public static final String LUCENE_SEARCH_INDEX__DEFAULT_FIELD="defaultField";
+  public static final String LUCENE_SEARCH_INDEX__DEFAULT_FIELD__HELP="Default field to search in";
+  public static final String LUCENE_SEARCH_INDEX__NO_RESULTS_MESSAGE="No results";
 }

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneQueryInfo.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneQueryInfo.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gemstone.gemfire.cache.lucene.internal.cli;
+
+import java.io.Serializable;
+
+public class LuceneQueryInfo implements Serializable {
+  private static final long serialVersionUID = 1L;
+  private String indexName;
+  private String regionPath;
+  private String queryString;
+  private String defaultField;
+
+  public LuceneQueryInfo(final String indexName,
+                         final String regionPath,
+                         final String queryString,
+                         final String defaultField)
+  {
+    this.indexName = indexName;
+    this.regionPath = regionPath;
+    this.queryString = queryString;
+    this.defaultField = defaultField;
+  }
+
+  public String getIndexName() {
+    return indexName;
+  }
+
+  public String getRegionPath() {
+    return regionPath;
+  }
+
+  public String getQueryString() {
+    return queryString;
+  }
+
+  public String getDefaultField() {
+    return defaultField;
+  }
+}

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneSearchResults.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneSearchResults.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gemstone.gemfire.cache.lucene.internal.cli;
+
+import java.io.Serializable;
+
+public class LuceneSearchResults<K,V> implements Comparable<LuceneSearchResults>, Serializable {
+
+  private String key;
+  private String value;
+  private float score;
+
+  public LuceneSearchResults(final String key, final String value, final float score) {
+    this.key = key;
+    this.value = value;
+    this.score = score;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public float getScore() {
+    return score;
+  }
+
+  @Override
+  public int compareTo(final LuceneSearchResults searchResults) {
+    return getScore() < searchResults.getScore() ? -1 : 1;
+  }
+}

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneSearchIndexFunction.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneSearchIndexFunction.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gemstone.gemfire.cache.lucene.internal.cli.functions;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.gemstone.gemfire.cache.Cache;
+import com.gemstone.gemfire.cache.CacheFactory;
+import com.gemstone.gemfire.cache.execute.FunctionAdapter;
+import com.gemstone.gemfire.cache.execute.FunctionContext;
+import com.gemstone.gemfire.cache.lucene.LuceneQuery;
+import com.gemstone.gemfire.cache.lucene.LuceneQueryException;
+import com.gemstone.gemfire.cache.lucene.LuceneResultStruct;
+import com.gemstone.gemfire.cache.lucene.LuceneService;
+import com.gemstone.gemfire.cache.lucene.LuceneServiceProvider;
+import com.gemstone.gemfire.cache.lucene.PageableLuceneQueryResults;
+import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneIndexDetails;
+import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneIndexInfo;
+import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneQueryInfo;
+import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneSearchResults;
+import com.gemstone.gemfire.cache.query.RegionNotFoundException;
+import com.gemstone.gemfire.internal.InternalEntity;
+
+/**
+ * The LuceneSearchIndexFunction class is a function used to collect the information on a particular lucene index.
+ * </p>
+ * @see Cache
+ * @see com.gemstone.gemfire.cache.execute.Function
+ * @see FunctionAdapter
+ * @see FunctionContext
+ * @see InternalEntity
+ * @see LuceneIndexDetails
+ * @see LuceneIndexInfo
+ */
+@SuppressWarnings("unused")
+public class LuceneSearchIndexFunction<K,V> extends FunctionAdapter implements InternalEntity {
+
+  protected Cache getCache() {
+    return CacheFactory.getAnyInstance();
+  }
+
+  public String getId() {
+    return LuceneSearchIndexFunction.class.getName();
+  }
+
+  public void execute(final FunctionContext context)   {
+
+    Set<LuceneSearchResults> result=new HashSet<>();
+    final Cache cache = getCache();
+    final LuceneQueryInfo queryInfo = (LuceneQueryInfo) context.getArguments();
+
+    LuceneService luceneService = LuceneServiceProvider.get(getCache());
+    try {
+      if (cache.getRegion(queryInfo.getRegionPath())!=null) {
+        final LuceneQuery<K, V> query = luceneService.createLuceneQueryFactory().create(
+          queryInfo.getIndexName(), queryInfo.getRegionPath(), queryInfo.getQueryString(), queryInfo.getDefaultField());
+        PageableLuceneQueryResults pageableLuceneQueryResults = query.findPages();
+        while (pageableLuceneQueryResults.hasNext()) {
+          List<LuceneResultStruct> page = pageableLuceneQueryResults.next();
+          page.stream()
+            .forEach(searchResult ->
+              result.add(new LuceneSearchResults<K,V>(searchResult.getKey().toString(),searchResult.getValue().toString(),searchResult.getScore())));
+        }
+      }
+      context.getResultSender().lastResult(result);
+    }
+    catch (LuceneQueryException e) {
+      context.getResultSender().lastResult(e);
+    }
+  }
+}

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneSearchIndexFunctionJUnitTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneSearchIndexFunctionJUnitTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gemstone.gemfire.cache.lucene.internal.cli.functions;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import com.gemstone.gemfire.cache.Region;
+import com.gemstone.gemfire.cache.execute.FunctionContext;
+import com.gemstone.gemfire.cache.execute.ResultSender;
+import com.gemstone.gemfire.cache.lucene.LuceneQuery;
+import com.gemstone.gemfire.cache.lucene.LuceneQueryException;
+import com.gemstone.gemfire.cache.lucene.LuceneQueryFactory;
+import com.gemstone.gemfire.cache.lucene.LuceneResultStruct;
+import com.gemstone.gemfire.cache.lucene.PageableLuceneQueryResults;
+import com.gemstone.gemfire.cache.lucene.internal.InternalLuceneService;
+import com.gemstone.gemfire.cache.lucene.internal.LuceneResultStructImpl;
+import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneQueryInfo;
+import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneSearchResults;
+import com.gemstone.gemfire.internal.cache.GemFireCacheImpl;
+import com.gemstone.gemfire.test.fake.Fakes;
+import com.gemstone.gemfire.test.junit.categories.UnitTest;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.ArgumentCaptor;
+
+@Category(UnitTest.class)
+
+public class LuceneSearchIndexFunctionJUnitTest {
+  
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testExecute() throws LuceneQueryException {
+    FunctionContext context = mock(FunctionContext.class);
+    ResultSender resultSender = mock(ResultSender.class);
+    GemFireCacheImpl cache = Fakes.cache();
+
+    LuceneQueryInfo queryInfo = createMockQueryInfo("index","region","field1:region1","field1");
+    InternalLuceneService service = getMockLuceneService("A","Value","1.2");
+    Region mockRegion=mock(Region.class);
+
+    LuceneSearchIndexFunction function = spy(LuceneSearchIndexFunction.class);
+
+    doReturn(queryInfo).when(context).getArguments();
+    doReturn(resultSender).when(context).getResultSender();
+    doReturn(cache).when(function).getCache();
+
+    when(cache.getService(eq(InternalLuceneService.class))).thenReturn(service);
+    when(cache.getRegion(queryInfo.getRegionPath())).thenReturn(mockRegion);
+
+    function.execute(context);
+    ArgumentCaptor<Set> resultCaptor  = ArgumentCaptor.forClass(Set.class);
+    verify(resultSender).lastResult(resultCaptor.capture());
+    Set<LuceneSearchResults> result = resultCaptor.getValue();
+
+    assertEquals(1,result.size());
+    for (LuceneSearchResults searchResult: result) {
+      assertEquals("A",searchResult.getKey());
+      assertEquals("Value",searchResult.getValue());
+      assertEquals(1.2,searchResult.getScore(),.1);
+    }
+  }
+  private InternalLuceneService getMockLuceneService(String resultKey, String resultValue, String resultScore) throws LuceneQueryException{
+    InternalLuceneService service=mock(InternalLuceneService.class);
+    LuceneQueryFactory mockQueryFactory = mock(LuceneQueryFactory.class);
+    LuceneQuery mockQuery=mock(LuceneQuery.class);
+    PageableLuceneQueryResults pageableLuceneQueryResults = mock(PageableLuceneQueryResults.class);
+    LuceneResultStruct<String,String> resultStruct = new LuceneResultStructImpl(resultKey,resultValue,Float.valueOf(resultScore));
+    List<LuceneResultStruct<String,String>> queryResults= new ArrayList<>();
+    queryResults.add(resultStruct);
+
+    doReturn(mockQueryFactory).when(service).createLuceneQueryFactory();
+    doReturn(mockQuery).when(mockQueryFactory).create(any(),any(),any(),any());
+    when(mockQuery.findPages()).thenReturn(pageableLuceneQueryResults);
+    when(pageableLuceneQueryResults.hasNext()).thenReturn(true).thenReturn(false);
+    when(pageableLuceneQueryResults.next()).thenReturn(queryResults);
+
+    return service;
+  }
+
+  private LuceneQueryInfo createMockQueryInfo(final String index, final String region, final String query, final String field) {
+    LuceneQueryInfo queryInfo = mock(LuceneQueryInfo.class);
+    when(queryInfo.getIndexName()).thenReturn(index);
+    when(queryInfo.getRegionPath()).thenReturn(region);
+    when(queryInfo.getQueryString()).thenReturn(query);
+    when(queryInfo.getDefaultField()).thenReturn(field);
+    return queryInfo;
+  }
+
+}


### PR DESCRIPTION
Added a gfsh command to execute a basic search operation on the lucene index. Added junit and dunit tests to verify.