### PR TITLE
feature/GEODE-11-Defining lucene index 

### DIFF
--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/LuceneService.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/LuceneService.java
@@ -23,6 +23,7 @@ import org.apache.lucene.analysis.Analyzer;
 
 import com.gemstone.gemfire.annotations.Experimental;
 import com.gemstone.gemfire.cache.GemFireCache;
+import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexCreationProfile;
 
 /**
  * LuceneService instance is a singleton for each cache.
@@ -124,4 +125,18 @@ public interface LuceneService {
    * @return LuceneQueryFactory object
    */
   public LuceneQueryFactory createLuceneQueryFactory();
+
+  /**
+   * get all defined lucene indexes (that haven't been initialized)
+   * @return all defined index profiles in a Collection
+   */
+  public Collection<LuceneIndexCreationProfile> getAllDefinedIndexes();
+
+  /**
+   * Get the lucene index creation profile specified by region name and index name
+   * @param indexName index name
+   * @param regionPath region name
+   * @return LuceneIndexCreationProfile object
+   */
+  public LuceneIndexCreationProfile getDefinedIndex(String indexName, String regionPath);
 }

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/LuceneService.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/LuceneService.java
@@ -126,17 +126,4 @@ public interface LuceneService {
    */
   public LuceneQueryFactory createLuceneQueryFactory();
 
-  /**
-   * get all defined lucene indexes (that haven't been initialized)
-   * @return all defined index profiles in a Collection
-   */
-  public Collection<LuceneIndexCreationProfile> getAllDefinedIndexes();
-
-  /**
-   * Get the lucene index creation profile specified by region name and index name
-   * @param indexName index name
-   * @param regionPath region name
-   * @return LuceneIndexCreationProfile object
-   */
-  public LuceneIndexCreationProfile getDefinedIndex(String indexName, String regionPath);
-}
+ }

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/LuceneIndexCreationProfile.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/LuceneIndexCreationProfile.java
@@ -38,12 +38,23 @@ public class LuceneIndexCreationProfile implements CacheServiceProfile, DataSeri
 
   private Map<String, Class<? extends Analyzer>> fieldAnalyzers;
 
+  private String regionPath;
+
   /* Used by DataSerializer */
   public LuceneIndexCreationProfile() {}
 
   public LuceneIndexCreationProfile(String indexName, String[] fieldNames, Analyzer analyzer,
       Map<String, Analyzer> fieldAnalyzers) {
     this.indexName = indexName;
+    this.fieldNames = fieldNames;
+    this.analyzerClass = analyzer.getClass();
+    initializeFieldAnalyzers(fieldAnalyzers);
+  }
+
+  public LuceneIndexCreationProfile(String indexName, String regionPath, String[] fieldNames, Analyzer analyzer,
+                                    Map<String, Analyzer> fieldAnalyzers) {
+    this.indexName = indexName;
+    this.regionPath = regionPath;
     this.fieldNames = fieldNames;
     this.analyzerClass = analyzer.getClass();
     initializeFieldAnalyzers(fieldAnalyzers);
@@ -185,5 +196,9 @@ public class LuceneIndexCreationProfile implements CacheServiceProfile, DataSeri
         .append(this.fieldAnalyzers)
         .append("]")
         .toString();
+  }
+
+  public String getRegionPath() {
+    return this.regionPath;
   }
 }

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/LuceneServiceImpl.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/LuceneServiceImpl.java
@@ -69,7 +69,8 @@ public class LuceneServiceImpl implements InternalLuceneService {
   private static final Logger logger = LogService.getLogger();
 
   private GemFireCacheImpl cache;
-  private final HashMap<String, LuceneIndex> indexMap = new HashMap<String, LuceneIndex>();;
+  private final HashMap<String, LuceneIndex> indexMap = new HashMap<String, LuceneIndex>();
+  private final HashMap<String, LuceneIndexCreationProfile> definedIndexMap = new HashMap<>();
 
   public LuceneServiceImpl() {
     
@@ -136,6 +137,10 @@ public class LuceneServiceImpl implements InternalLuceneService {
     if(!regionPath.startsWith("/")) {
       regionPath = "/" + regionPath;
     }
+
+    registerDefinedIndex(LuceneServiceImpl.getUniqueIndexName(indexName, regionPath),
+                                new LuceneIndexCreationProfile(indexName, regionPath, fields, analyzer, fieldAnalyzers));
+
     Region region = cache.getRegion(regionPath);
     if(region != null) {
       throw new IllegalStateException("The lucene index must be created before region");
@@ -172,7 +177,8 @@ public class LuceneServiceImpl implements InternalLuceneService {
     });
     
   }
-  
+
+
   /**
    * Finish creating the lucene index after the data region is created .
    * 
@@ -216,6 +222,12 @@ public class LuceneServiceImpl implements InternalLuceneService {
       throw new UnsupportedOperationException("Lucene indexes on replicated regions are not supported");
     }
     return index;
+  }
+
+  private void registerDefinedIndex(final String regionAndIndex, final LuceneIndexCreationProfile luceneIndexCreationProfile) {
+    if (definedIndexMap.containsKey(regionAndIndex) || indexMap.containsKey(regionAndIndex))
+      throw new IllegalArgumentException("Lucene index already exists in region");
+    definedIndexMap.put(regionAndIndex, luceneIndexCreationProfile);
   }
 
   @Override
@@ -265,6 +277,7 @@ public class LuceneServiceImpl implements InternalLuceneService {
     if( !indexMap.containsKey( regionAndIndex )) {
       indexMap.put(regionAndIndex, index);
     }
+    definedIndexMap.remove(regionAndIndex);
   }
 
   public void unregisterIndex(final String region){
@@ -304,5 +317,15 @@ public class LuceneServiceImpl implements InternalLuceneService {
     DSFIDFactory.registerDSFID(
         DataSerializableFixedID.LUCENE_TOP_ENTRIES_COLLECTOR,
         TopEntriesCollector.class);
+  }
+
+  @Override
+  public Collection<LuceneIndexCreationProfile> getAllDefinedIndexes() {
+    return definedIndexMap.values();
+  }
+
+  @Override
+  public LuceneIndexCreationProfile getDefinedIndex(String indexName, String regionPath) {
+    return definedIndexMap.get(getUniqueIndexName(indexName , regionPath));
   }
 }

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/LuceneServiceImpl.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/LuceneServiceImpl.java
@@ -319,12 +319,10 @@ public class LuceneServiceImpl implements InternalLuceneService {
         TopEntriesCollector.class);
   }
 
-  @Override
   public Collection<LuceneIndexCreationProfile> getAllDefinedIndexes() {
     return definedIndexMap.values();
   }
 
-  @Override
   public LuceneIndexCreationProfile getDefinedIndex(String indexName, String regionPath) {
     return definedIndexMap.get(getUniqueIndexName(indexName , regionPath));
   }

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommands.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommands.java
@@ -16,9 +16,6 @@
  */
 package com.gemstone.gemfire.cache.lucene.internal.cli;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -34,8 +31,6 @@ import com.gemstone.gemfire.cache.execute.Execution;
 import com.gemstone.gemfire.cache.execute.FunctionAdapter;
 import com.gemstone.gemfire.cache.execute.FunctionInvocationTargetException;
 import com.gemstone.gemfire.cache.execute.ResultCollector;
-import com.gemstone.gemfire.cache.lucene.LuceneResultStruct;
-import com.gemstone.gemfire.cache.lucene.PageableLuceneQueryResults;
 import com.gemstone.gemfire.cache.lucene.internal.cli.functions.LuceneCreateIndexFunction;
 import com.gemstone.gemfire.cache.lucene.internal.cli.functions.LuceneDescribeIndexFunction;
 import com.gemstone.gemfire.cache.lucene.internal.cli.functions.LuceneListIndexFunction;
@@ -124,10 +119,10 @@ public class LuceneIndexCommands extends AbstractCommandsSupport {
         indexData.accumulate("Region Path", indexDetails.getRegionPath());
         indexData.accumulate("Indexed Fields", indexDetails.getSearchableFieldNamesString());
         indexData.accumulate("Field Analyzer", indexDetails.getFieldAnalyzersString());
-        indexData.accumulate("Status", indexDetails.getStatus());
+        indexData.accumulate("Status", indexDetails.getInitialized() == true ? "Initialized" : "Defined");
 
         if (stats == true) {
-          if (indexDetails.getStatus() == "Defined") {
+          if (!indexDetails.getInitialized()) {
             indexData.accumulate("Query Executions", "NA");
             indexData.accumulate("Updates", "NA");
             indexData.accumulate("Commits", "NA");

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommands.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommands.java
@@ -124,12 +124,21 @@ public class LuceneIndexCommands extends AbstractCommandsSupport {
         indexData.accumulate("Region Path", indexDetails.getRegionPath());
         indexData.accumulate("Indexed Fields", indexDetails.getSearchableFieldNamesString());
         indexData.accumulate("Field Analyzer", indexDetails.getFieldAnalyzersString());
+        indexData.accumulate("Status", indexDetails.getStatus());
 
-        if (stats==true) {
-          indexData.accumulate("Query Executions",indexDetails.getIndexStats().get("queryExecutions"));
-          indexData.accumulate("Updates",indexDetails.getIndexStats().get("updates"));
-          indexData.accumulate("Commits",indexDetails.getIndexStats().get("commits"));
-          indexData.accumulate("Documents",indexDetails.getIndexStats().get("documents"));
+        if (stats == true) {
+          if (indexDetails.getStatus() == "Defined") {
+            indexData.accumulate("Query Executions", "NA");
+            indexData.accumulate("Updates", "NA");
+            indexData.accumulate("Commits", "NA");
+            indexData.accumulate("Documents", "NA");
+          }
+          else {
+            indexData.accumulate("Query Executions", indexDetails.getIndexStats().get("queryExecutions"));
+            indexData.accumulate("Updates", indexDetails.getIndexStats().get("updates"));
+            indexData.accumulate("Commits", indexDetails.getIndexStats().get("commits"));
+            indexData.accumulate("Documents", indexDetails.getIndexStats().get("documents"));
+          }
         }
       }
       return ResultBuilder.buildResult(indexData);

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexDetails.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexDetails.java
@@ -36,15 +36,15 @@ public class LuceneIndexDetails implements Comparable<LuceneIndexDetails>, Seria
   private final String[] searchableFieldNames;
   private Map<String, String> fieldAnalyzers=null;
   private final Map<String,Integer> indexStats;
-  private boolean status;
+  private boolean initialized;
 
-  public LuceneIndexDetails(final String indexName, final String regionPath, final String[] searchableFieldNames, final Map<String, Analyzer> fieldAnalyzers, LuceneIndexStats indexStats, boolean status) {
+  public LuceneIndexDetails(final String indexName, final String regionPath, final String[] searchableFieldNames, final Map<String, Analyzer> fieldAnalyzers, LuceneIndexStats indexStats, boolean initialized) {
     this.indexName = indexName;
     this.regionPath = regionPath;
     this.searchableFieldNames = searchableFieldNames;
-    this.fieldAnalyzers = setFieldAnalyzerStrings(fieldAnalyzers);
+    this.fieldAnalyzers = getFieldAnalyzerStrings(fieldAnalyzers);
     this.indexStats=getIndexStatsMap(indexStats);
-    this.status = status;
+    this.initialized = initialized;
   }
 
   public LuceneIndexDetails(LuceneIndexImpl index) {
@@ -53,7 +53,7 @@ public class LuceneIndexDetails implements Comparable<LuceneIndexDetails>, Seria
 
   public LuceneIndexDetails(LuceneIndexCreationProfile indexProfile) {
     this(indexProfile.getIndexName(), indexProfile.getRegionPath(), indexProfile.getFieldNames(), null, null, false);
-    this.fieldAnalyzers=setFieldAnalyzerStringsFromProfile(indexProfile.getFieldAnalyzers());
+    this.fieldAnalyzers=getFieldAnalyzerStringsFromProfile(indexProfile.getFieldAnalyzers());
   }
 
   public Map<String,Integer> getIndexStats() {
@@ -73,7 +73,7 @@ public class LuceneIndexDetails implements Comparable<LuceneIndexDetails>, Seria
     return indexStats.toString();
   }
 
-  private Map<String, String> setFieldAnalyzerStrings(Map<String, Analyzer> fieldAnalyzers) {
+  private Map<String, String> getFieldAnalyzerStrings(Map<String, Analyzer> fieldAnalyzers) {
     if(fieldAnalyzers == null) {
       return Collections.emptyMap();
     }
@@ -89,9 +89,10 @@ public class LuceneIndexDetails implements Comparable<LuceneIndexDetails>, Seria
     return results;
   }
 
-  private Map<String, String> setFieldAnalyzerStringsFromProfile(Map<String, Class <? extends Analyzer>> fieldAnalyzers) {
+  private Map<String, String> getFieldAnalyzerStringsFromProfile(Map<String, Class <? extends Analyzer>> fieldAnalyzers) {
     if(fieldAnalyzers == null) {
       return Collections.emptyMap();
+
     }
 
     Map<String, String> results = new HashMap<>();
@@ -121,14 +122,14 @@ public class LuceneIndexDetails implements Comparable<LuceneIndexDetails>, Seria
     buffer.append(",\tRegion Path = "+regionPath);
     buffer.append(",\tIndexed Fields = "+getSearchableFieldNamesString());
     buffer.append(",\tField Analyzer = "+getFieldAnalyzersString());
-    buffer.append(",\tStatus =\n\t"+getStatus());
+    buffer.append(",\tStatus =\n\t"+ getInitialized());
     buffer.append(",\tIndex Statistics =\n\t"+getIndexStatsString());
     buffer.append("\n}\n");
     return buffer.toString();
   }
 
-  public String getStatus() {
-    return status==true ? "Initialized" : "Defined";
+  public boolean getInitialized() {
+    return initialized;
   }
 
   public String getIndexName() {

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneDescribeIndexFunction.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneDescribeIndexFunction.java
@@ -27,6 +27,7 @@ import com.gemstone.gemfire.cache.execute.FunctionContext;
 import com.gemstone.gemfire.cache.lucene.LuceneIndex;
 import com.gemstone.gemfire.cache.lucene.LuceneService;
 import com.gemstone.gemfire.cache.lucene.LuceneServiceProvider;
+import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexCreationProfile;
 import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexImpl;
 import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneIndexDetails;
 import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneIndexInfo;
@@ -56,12 +57,16 @@ public class LuceneDescribeIndexFunction extends FunctionAdapter implements Inte
 
   public void execute(final FunctionContext context) {
     LuceneIndexDetails result = null;
+
     final Cache cache = getCache();
     final LuceneIndexInfo indexInfo = (LuceneIndexInfo) context.getArguments();
     LuceneService service = LuceneServiceProvider.get(cache);
     LuceneIndex index = service.getIndex(indexInfo.getIndexName(), indexInfo.getRegionPath());
+    LuceneIndexCreationProfile profile = service.getDefinedIndex(indexInfo.getIndexName(),indexInfo.getRegionPath());
     if (index != null) {
       result = new LuceneIndexDetails((LuceneIndexImpl) index);
+    } else if (profile != null) {
+     result = new LuceneIndexDetails(profile);
     }
     context.getResultSender().lastResult(result);
   }

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneDescribeIndexFunction.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneDescribeIndexFunction.java
@@ -29,6 +29,7 @@ import com.gemstone.gemfire.cache.lucene.LuceneService;
 import com.gemstone.gemfire.cache.lucene.LuceneServiceProvider;
 import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexCreationProfile;
 import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexImpl;
+import com.gemstone.gemfire.cache.lucene.internal.LuceneServiceImpl;
 import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneIndexDetails;
 import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneIndexInfo;
 import com.gemstone.gemfire.internal.InternalEntity;
@@ -60,7 +61,7 @@ public class LuceneDescribeIndexFunction extends FunctionAdapter implements Inte
 
     final Cache cache = getCache();
     final LuceneIndexInfo indexInfo = (LuceneIndexInfo) context.getArguments();
-    LuceneService service = LuceneServiceProvider.get(cache);
+    LuceneServiceImpl service = (LuceneServiceImpl) LuceneServiceProvider.get(cache);
     LuceneIndex index = service.getIndex(indexInfo.getIndexName(), indexInfo.getRegionPath());
     LuceneIndexCreationProfile profile = service.getDefinedIndex(indexInfo.getIndexName(),indexInfo.getRegionPath());
     if (index != null) {

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneListIndexFunction.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneListIndexFunction.java
@@ -27,6 +27,7 @@ import com.gemstone.gemfire.cache.execute.FunctionContext;
 import com.gemstone.gemfire.cache.lucene.LuceneIndex;
 import com.gemstone.gemfire.cache.lucene.LuceneService;
 import com.gemstone.gemfire.cache.lucene.LuceneServiceProvider;
+import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexCreationProfile;
 import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexImpl;
 import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneIndexDetails;
 import com.gemstone.gemfire.internal.InternalEntity;
@@ -59,6 +60,10 @@ public class LuceneListIndexFunction extends FunctionAdapter implements Internal
     LuceneService service = LuceneServiceProvider.get(cache);
     for (LuceneIndex index : service.getAllIndexes()) {
       indexDetailsSet.add(new LuceneIndexDetails((LuceneIndexImpl) index));
+    }
+
+    for(LuceneIndexCreationProfile profile : service.getAllDefinedIndexes()) {
+      indexDetailsSet.add(new LuceneIndexDetails(profile));
     }
     context.getResultSender().lastResult(indexDetailsSet);
   }

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneListIndexFunction.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneListIndexFunction.java
@@ -29,6 +29,7 @@ import com.gemstone.gemfire.cache.lucene.LuceneService;
 import com.gemstone.gemfire.cache.lucene.LuceneServiceProvider;
 import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexCreationProfile;
 import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexImpl;
+import com.gemstone.gemfire.cache.lucene.internal.LuceneServiceImpl;
 import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneIndexDetails;
 import com.gemstone.gemfire.internal.InternalEntity;
 
@@ -57,7 +58,7 @@ public class LuceneListIndexFunction extends FunctionAdapter implements Internal
   public void execute(final FunctionContext context) {
     final Set<LuceneIndexDetails> indexDetailsSet = new HashSet<>();
     final Cache cache = getCache();
-    LuceneService service = LuceneServiceProvider.get(cache);
+    LuceneServiceImpl service = (LuceneServiceImpl) LuceneServiceProvider.get(cache);
     for (LuceneIndex index : service.getAllIndexes()) {
       indexDetailsSet.add(new LuceneIndexDetails((LuceneIndexImpl) index));
     }
@@ -67,5 +68,4 @@ public class LuceneListIndexFunction extends FunctionAdapter implements Internal
     }
     context.getResultSender().lastResult(indexDetailsSet);
   }
-
 }

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/LuceneIndexCreationIntegrationTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/LuceneIndexCreationIntegrationTest.java
@@ -46,6 +46,7 @@ import com.gemstone.gemfire.cache.Region;
 import com.gemstone.gemfire.cache.RegionFactory;
 import com.gemstone.gemfire.cache.RegionShortcut;
 import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexCreationProfile;
+import com.gemstone.gemfire.cache.lucene.internal.LuceneServiceImpl;
 import com.gemstone.gemfire.cache.lucene.test.LuceneTestUtilities;
 import com.gemstone.gemfire.cache.lucene.test.TestObject;
 import com.gemstone.gemfire.internal.cache.BucketNotFoundException;
@@ -192,9 +193,10 @@ public class LuceneIndexCreationIntegrationTest extends LuceneIntegrationTest {
   @Test
   public void shouldReturnAllDefinedIndexes()
   {
-    luceneService.createIndex(INDEX_NAME,REGION_NAME,"field1","field2","field3");
-    luceneService.createIndex("index2", "region2", "field4","field5","field6");
-    final Collection<LuceneIndexCreationProfile> indexList = luceneService.getAllDefinedIndexes();
+    LuceneServiceImpl luceneServiceImpl = (LuceneServiceImpl) luceneService;
+    luceneServiceImpl.createIndex(INDEX_NAME,REGION_NAME,"field1","field2","field3");
+    luceneServiceImpl.createIndex("index2", "region2", "field4","field5","field6");
+    final Collection<LuceneIndexCreationProfile> indexList = luceneServiceImpl.getAllDefinedIndexes();
 
     assertEquals(Arrays.asList(INDEX_NAME,"index2"), indexList.stream().map(LuceneIndexCreationProfile::getIndexName)
                                                               .sorted().collect(Collectors.toList()));

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/LuceneIndexCreationIntegrationTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/LuceneIndexCreationIntegrationTest.java
@@ -27,11 +27,15 @@ import static org.junit.Assert.*;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 import com.gemstone.gemfire.cache.EvictionAction;
 import com.gemstone.gemfire.cache.EvictionAttributes;
@@ -41,6 +45,7 @@ import com.gemstone.gemfire.cache.PartitionAttributesFactory;
 import com.gemstone.gemfire.cache.Region;
 import com.gemstone.gemfire.cache.RegionFactory;
 import com.gemstone.gemfire.cache.RegionShortcut;
+import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexCreationProfile;
 import com.gemstone.gemfire.cache.lucene.test.LuceneTestUtilities;
 import com.gemstone.gemfire.cache.lucene.test.TestObject;
 import com.gemstone.gemfire.internal.cache.BucketNotFoundException;
@@ -174,6 +179,28 @@ public class LuceneIndexCreationIntegrationTest extends LuceneIntegrationTest {
     RegionFactory regionFactory = this.cache.createRegionFactory(RegionShortcut.PARTITION);
     regionFactory.setEvictionAttributes(EvictionAttributes.createLIFOEntryAttributes(100, EvictionAction.LOCAL_DESTROY));
     regionFactory.create(REGION_NAME);
+  }
+
+  @Test
+  public void cannotCreateLuceneIndexWithExistingIndexName()
+  {
+    expectedException.expect(IllegalArgumentException.class);
+    createIndex("field1","field2","field3");
+    createIndex("field4","field5","field6");
+  }
+
+  @Test
+  public void shouldReturnAllDefinedIndexes()
+  {
+    luceneService.createIndex(INDEX_NAME,REGION_NAME,"field1","field2","field3");
+    luceneService.createIndex("index2", "region2", "field4","field5","field6");
+    final Collection<LuceneIndexCreationProfile> indexList = luceneService.getAllDefinedIndexes();
+
+    assertEquals(Arrays.asList(INDEX_NAME,"index2"), indexList.stream().map(LuceneIndexCreationProfile::getIndexName)
+                                                              .sorted().collect(Collectors.toList()));
+    createRegion();
+    assertEquals(Collections.singletonList("index2"), indexList.stream().map(LuceneIndexCreationProfile::getIndexName)
+                                                    .collect(Collectors.toList()));
   }
 
   private void verifyInternalRegions(Consumer<LocalRegion> verify) {

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
@@ -24,6 +24,7 @@ import com.gemstone.gemfire.cache.lucene.LuceneService;
 import com.gemstone.gemfire.cache.lucene.LuceneServiceProvider;
 import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexCreationProfile;
 import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexImpl;
+import com.gemstone.gemfire.cache.lucene.internal.LuceneServiceImpl;
 import com.gemstone.gemfire.distributed.ConfigurationProperties;
 import com.gemstone.gemfire.management.cli.Result.Status;
 import com.gemstone.gemfire.management.internal.cli.CommandManager;
@@ -260,7 +261,7 @@ public class LuceneIndexCommandsDUnitTest extends CliCommandTestBase {
     String resultAsString = executeCommandAndLogResult(csb);
 
     vm1.invoke(() -> {
-      LuceneService luceneService = LuceneServiceProvider.get(getCache());
+      LuceneServiceImpl luceneService = (LuceneServiceImpl) LuceneServiceProvider.get(getCache());
       final ArrayList<LuceneIndexCreationProfile> profiles= new ArrayList<> (luceneService.getAllDefinedIndexes());
       assertEquals(1, profiles.size());
       assertEquals(INDEX_NAME, profiles.get(0).getIndexName());

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneDescribeIndexFunctionJUnitTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneDescribeIndexFunctionJUnitTest.java
@@ -30,6 +30,7 @@ import com.gemstone.gemfire.cache.execute.ResultSender;
 import com.gemstone.gemfire.cache.lucene.LuceneIndex;
 import com.gemstone.gemfire.cache.lucene.internal.InternalLuceneService;
 import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexImpl;
+import com.gemstone.gemfire.cache.lucene.internal.LuceneServiceImpl;
 import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneIndexDetails;
 import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneIndexInfo;
 import com.gemstone.gemfire.internal.cache.GemFireCacheImpl;
@@ -52,7 +53,7 @@ public class LuceneDescribeIndexFunctionJUnitTest {
   @SuppressWarnings("unchecked")
   public void testExecute() throws Throwable {
     GemFireCacheImpl cache = Fakes.cache();
-    InternalLuceneService service = mock(InternalLuceneService.class);
+    LuceneServiceImpl service = mock(LuceneServiceImpl.class);
     when(cache.getService(InternalLuceneService.class)).thenReturn(service);
     FunctionContext context = mock(FunctionContext.class);
     ResultSender resultSender = mock(ResultSender.class);

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneListIndexFunctionJUnitTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneListIndexFunctionJUnitTest.java
@@ -39,6 +39,7 @@ import com.gemstone.gemfire.cache.execute.ResultSender;
 import com.gemstone.gemfire.cache.lucene.LuceneIndex;
 import com.gemstone.gemfire.cache.lucene.internal.InternalLuceneService;
 import com.gemstone.gemfire.cache.lucene.internal.LuceneIndexImpl;
+import com.gemstone.gemfire.cache.lucene.internal.LuceneServiceImpl;
 import com.gemstone.gemfire.cache.lucene.internal.cli.LuceneIndexDetails;
 import com.gemstone.gemfire.internal.cache.GemFireCacheImpl;
 import com.gemstone.gemfire.test.fake.Fakes;
@@ -52,7 +53,7 @@ public class LuceneListIndexFunctionJUnitTest {
   @SuppressWarnings("unchecked")
   public void testExecute() throws Throwable {
     GemFireCacheImpl cache = Fakes.cache();
-    InternalLuceneService service = mock(InternalLuceneService.class);
+    LuceneServiceImpl service = mock(LuceneServiceImpl.class);
     when(cache.getService(InternalLuceneService.class)).thenReturn(service);
     
     FunctionContext context = mock(FunctionContext.class);


### PR DESCRIPTION
- Added a definedIndexMap field in LuceneServiceImpl to store the uninitialized lucene indexes
- Added a field "status" to the list and describe lucene gfsh commands to differentiate between defined and initialized indexes.
- Added a dunit test for the create index gfsh command to verify if the indexes created through gfsh are stored in definedIndexMap.