### PR TITLE
GEODE-1682: Adding options for starting Geode REST API using gfsh

### DIFF
--- a/geode-core/src/main/java/com/gemstone/gemfire/cache/server/CacheServer.java
+++ b/geode-core/src/main/java/com/gemstone/gemfire/cache/server/CacheServer.java
@@ -143,6 +143,11 @@ public interface CacheServer {
    */
   public static final boolean DEFAULT_TCP_NO_DELAY = true;
 
+
+  public static final int HTTP_DEFAULT_PORT = 8080;
+  public static final String HTTP_SERVICE_DEFAULT_BIND_ADDRESS = "";
+
+
   /**
    * Returns the port on which this cache server listens for clients.
    */

--- a/geode-core/src/main/java/com/gemstone/gemfire/management/internal/cli/commands/LauncherLifecycleCommands.java
+++ b/geode-core/src/main/java/com/gemstone/gemfire/management/internal/cli/commands/LauncherLifecycleCommands.java
@@ -1484,7 +1484,20 @@ public class LauncherLifecycleCommands extends AbstractCommandsSupport {
           unspecifiedDefaultValue = "true",
           specifiedDefaultValue = "true",
           help = CliStrings.START_SERVER__USE_CLUSTER_CONFIGURATION__HELP)
-      final Boolean requestSharedConfiguration)
+      final Boolean requestSharedConfiguration,
+          @CliOption(key = CliStrings.START_SERVER__REST_API,
+          unspecifiedDefaultValue = "false",
+          specifiedDefaultValue = "true",
+          help = CliStrings.START_SERVER__REST_API__HELP)
+      final Boolean startRestApi,
+          @CliOption(key = CliStrings.START_SERVER__HTTP_SERVICE_PORT,
+            unspecifiedDefaultValue = ("" + CacheServer.HTTP_DEFAULT_PORT),
+            help = CliStrings.START_SERVER__HTTP_SERVICE_PORT__HELP)
+      final String httpServicePort,
+          @CliOption(key = CliStrings.START_SERVER__HTTP_SERVICE_BIND_ADDRESS,
+           unspecifiedDefaultValue = CacheServer.HTTP_SERVICE_DEFAULT_BIND_ADDRESS,
+           help = CliStrings.START_SERVER__HTTP_SERVICE_BIND_ADDRESS__HELP)
+           final String httpServiceBindAddress)
   // NOTICE: keep the parameters in alphabetical order based on their CliStrings.START_SERVER_* text
   {
 
@@ -1546,6 +1559,11 @@ public class LauncherLifecycleCommands extends AbstractCommandsSupport {
       gemfireProperties.setProperty(USE_CLUSTER_CONFIGURATION, StringUtils.valueOf(requestSharedConfiguration, Boolean.TRUE.toString()));
       gemfireProperties.setProperty(LOCK_MEMORY, StringUtils.valueOf(lockMemory, StringUtils.EMPTY_STRING));
       gemfireProperties.setProperty(OFF_HEAP_MEMORY_SIZE, StringUtils.valueOf(offHeapMemorySize, StringUtils.EMPTY_STRING));
+
+      gemfireProperties.setProperty(DistributionConfig.START_DEV_REST_API_NAME, StringUtils.valueOf(startRestApi, StringUtils.EMPTY_STRING));
+      gemfireProperties.setProperty(DistributionConfig.HTTP_SERVICE_PORT_NAME,  StringUtils.valueOf(httpServicePort, StringUtils.EMPTY_STRING));
+      gemfireProperties.setProperty(DistributionConfig.HTTP_SERVICE_BIND_ADDRESS_NAME,  StringUtils.valueOf(httpServiceBindAddress, StringUtils.EMPTY_STRING));
+
 
       // read the OSProcess enable redirect system property here -- TODO: replace with new GFSH argument
       final boolean redirectOutput = Boolean.getBoolean(OSProcess.ENABLE_OUTPUT_REDIRECTION_PROPERTY);

--- a/geode-core/src/main/java/com/gemstone/gemfire/management/internal/cli/commands/LauncherLifecycleCommands.java
+++ b/geode-core/src/main/java/com/gemstone/gemfire/management/internal/cli/commands/LauncherLifecycleCommands.java
@@ -1560,9 +1560,9 @@ public class LauncherLifecycleCommands extends AbstractCommandsSupport {
       gemfireProperties.setProperty(LOCK_MEMORY, StringUtils.valueOf(lockMemory, StringUtils.EMPTY_STRING));
       gemfireProperties.setProperty(OFF_HEAP_MEMORY_SIZE, StringUtils.valueOf(offHeapMemorySize, StringUtils.EMPTY_STRING));
 
-      gemfireProperties.setProperty(DistributionConfig.START_DEV_REST_API_NAME, StringUtils.valueOf(startRestApi, StringUtils.EMPTY_STRING));
-      gemfireProperties.setProperty(DistributionConfig.HTTP_SERVICE_PORT_NAME,  StringUtils.valueOf(httpServicePort, StringUtils.EMPTY_STRING));
-      gemfireProperties.setProperty(DistributionConfig.HTTP_SERVICE_BIND_ADDRESS_NAME,  StringUtils.valueOf(httpServiceBindAddress, StringUtils.EMPTY_STRING));
+      gemfireProperties.setProperty(START_DEV_REST_API, StringUtils.valueOf(startRestApi, StringUtils.EMPTY_STRING));
+      gemfireProperties.setProperty(HTTP_SERVICE_PORT,  StringUtils.valueOf(httpServicePort, StringUtils.EMPTY_STRING));
+      gemfireProperties.setProperty(HTTP_SERVICE_BIND_ADDRESS,  StringUtils.valueOf(httpServiceBindAddress, StringUtils.EMPTY_STRING));
 
 
       // read the OSProcess enable redirect system property here -- TODO: replace with new GFSH argument

--- a/geode-core/src/main/java/com/gemstone/gemfire/management/internal/cli/i18n/CliStrings.java
+++ b/geode-core/src/main/java/com/gemstone/gemfire/management/internal/cli/i18n/CliStrings.java
@@ -2194,7 +2194,14 @@ public class CliStrings {
   public static final String PDX_DELETE_FIELD__SUCCESS = "Successfully deleted field in types:\n{0}";
   public static final String PDX_DELETE_FIELD__ERROR = "Error deleting field : {0}";
   public static final String PDX_DELETE__EMPTY = "Field to be deleted not found in the class.";
-  
+
+
+  public static final String START_SERVER__REST_API = "start-rest-api";
+  public static final String START_SERVER__REST_API__HELP = "When set to true, will start the REST API service.";
+  public static final String START_SERVER__HTTP_SERVICE_PORT = "http-service-port";
+  public static final String START_SERVER__HTTP_SERVICE_PORT__HELP = "Port on which HTTP Service will listen on";
+  public static final String START_SERVER__HTTP_SERVICE_BIND_ADDRESS = "http-service-bind-address";
+  public static final String START_SERVER__HTTP_SERVICE_BIND_ADDRESS__HELP = "The IP address on which the HTTP Service will be bound.  By default, the Server is bound to all local addresses.";
   /**
    * Creates a MessageFormat with the given pattern and uses it to format the given argument.
    *

--- a/geode-core/src/test/resources/com/gemstone/gemfire/management/internal/cli/commands/golden-help-offline.properties
+++ b/geode-core/src/test/resources/com/gemstone/gemfire/management/internal/cli/commands/golden-help-offline.properties
@@ -2521,6 +2521,7 @@ SYNTAX\n\
 \ \ \ \ [--rebalance(=value)?] [--security-properties-file=value] [--server-bind-address=value]\n\
 \ \ \ \ [--server-port=value] [--socket-buffer-size=value] [--spring-xml-location=value]\n\
 \ \ \ \ [--statistic-archive-file=value] [--use-cluster-configuration(=value)?]\n\
+\ \ \ \ [--start-rest-api(=value)?] [--http-service-port=value] [--http-service-bind-address=value]\n\
 PARAMETERS\n\
 \ \ \ \ assign-buckets\n\
 \ \ \ \ \ \ \ \ Whether to assign buckets to the partitioned regions of the cache on server start.\n\
@@ -2721,6 +2722,19 @@ PARAMETERS\n\
 \ \ \ \ \ \ \ \ Required: false\n\
 \ \ \ \ \ \ \ \ Default (if the parameter is specified without value): true\n\
 \ \ \ \ \ \ \ \ Default (if the parameter is not specified): true\n\
+\ \ \ \ start-rest-api\n\
+\ \ \ \ \ \ \ \ When set to true, will start the REST API service.\n\
+\ \ \ \ \ \ \ \ Required: false\n\
+\ \ \ \ \ \ \ \ Default (if the parameter is specified without value): true\n\
+\ \ \ \ \ \ \ \ Default (if the parameter is not specified): false\n\
+\ \ \ \ http-service-port\n\
+\ \ \ \ \ \ \ \ Port on which HTTP Service will listen on\n\
+\ \ \ \ \ \ \ \ Required: false\n\
+\ \ \ \ \ \ \ \ Default (if the parameter is not specified): 8080\n\
+\ \ \ \ http-service-bind-address\n\
+\ \ \ \ \ \ \ \ The IP address on which the HTTP Service will be bound.  By default, the Server is bound to\n\
+\ \ \ \ \ \ \ \ all local addresses.\n\
+\ \ \ \ \ \ \ \ Required: false\n\
 
 start-vsd.help=\
 NAME\n\


### PR DESCRIPTION
GEODE-1682: 

- Added option in gfsh to start REST `start-rest-api`
- Added option for http service port `http-service-port`
- Added option for http service bind address `http-service-bind-address`
- Update `gemfireProperties` to for `cache` creation.
- Verified Manually ( both with `start-rest-api` and without )
- Ran the precheckin 
   - Test Failing ( ConcurrentParallelGatewaySenderOffHeapDUnitTest#testPartitionedParallelPropagationHA