### PR TITLE
feature/GEODE-11-Lucene search with limit and pagination in gfsh

### DIFF
--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneCliStrings.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneCliStrings.java
@@ -18,8 +18,6 @@
  */
 package com.gemstone.gemfire.cache.lucene.internal.cli;
 
-import com.gemstone.gemfire.cache.lucene.LuceneQueryFactory;
-
 public class LuceneCliStrings {
   //Common parameters/options
   public static final String LUCENE__INDEX_NAME = "name";
@@ -73,4 +71,6 @@ public class LuceneCliStrings {
   public static final String LUCENE_SEARCH_INDEX__DEFAULT_FIELD="defaultField";
   public static final String LUCENE_SEARCH_INDEX__DEFAULT_FIELD__HELP="Default field to search in";
   public static final String LUCENE_SEARCH_INDEX__NO_RESULTS_MESSAGE="No results";
+  public static final String LUCENE_SEARCH_INDEX__PAGE_SIZE="pageSize";
+  public static final String LUCENE_SEARCH_INDEX__PAGE_SIZE__HELP="Number of results to be returned in a page";
 }

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneCliStrings.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneCliStrings.java
@@ -18,6 +18,8 @@
  */
 package com.gemstone.gemfire.cache.lucene.internal.cli;
 
+import com.gemstone.gemfire.cache.lucene.LuceneQueryFactory;
+
 public class LuceneCliStrings {
   //Common parameters/options
   public static final String LUCENE__INDEX_NAME = "name";
@@ -65,6 +67,8 @@ public class LuceneCliStrings {
   public static final String LUCENE_SEARCH_INDEX__NAME__HELP = "Name of the lucene index to search.";
   public static final String LUCENE_SEARCH_INDEX__REGION_HELP = "Name/Path of the region where the lucene index exists.";
   public static final String LUCENE_SEARCH_INDEX__QUERY_STRING="queryStrings";
+  public static final String LUCENE_SEARCH_INDEX__LIMIT="limit";
+  public static final String LUCENE_SEARCH_INDEX__LIMIT__HELP="Number of search results needed";
   public static final String LUCENE_SEARCH_INDEX__QUERY_STRING__HELP="Query string to search the lucene index";
   public static final String LUCENE_SEARCH_INDEX__DEFAULT_FIELD="defaultField";
   public static final String LUCENE_SEARCH_INDEX__DEFAULT_FIELD__HELP="Default field to search in";

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommands.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommands.java
@@ -31,6 +31,7 @@ import com.gemstone.gemfire.cache.execute.Execution;
 import com.gemstone.gemfire.cache.execute.FunctionAdapter;
 import com.gemstone.gemfire.cache.execute.FunctionInvocationTargetException;
 import com.gemstone.gemfire.cache.execute.ResultCollector;
+
 import com.gemstone.gemfire.cache.lucene.internal.cli.functions.LuceneCreateIndexFunction;
 import com.gemstone.gemfire.cache.lucene.internal.cli.functions.LuceneDescribeIndexFunction;
 import com.gemstone.gemfire.cache.lucene.internal.cli.functions.LuceneListIndexFunction;
@@ -272,10 +273,15 @@ public class LuceneIndexCommands extends AbstractCommandsSupport {
 
     @CliOption (key = LuceneCliStrings.LUCENE_SEARCH_INDEX__DEFAULT_FIELD,
       mandatory = true,
-      help = LuceneCliStrings.LUCENE_SEARCH_INDEX__DEFAULT_FIELD__HELP) final String defaultField) {
+      help = LuceneCliStrings.LUCENE_SEARCH_INDEX__DEFAULT_FIELD__HELP) final String defaultField,
+
+    @CliOption (key = LuceneCliStrings.LUCENE_SEARCH_INDEX__LIMIT,
+      mandatory = false,
+      unspecifiedDefaultValue = "-1",
+      help = LuceneCliStrings.LUCENE_SEARCH_INDEX__LIMIT__HELP) final int limit) {
     try {
 
-      LuceneQueryInfo queryInfo=new LuceneQueryInfo(indexName,regionPath,queryString, defaultField);
+      LuceneQueryInfo queryInfo=new LuceneQueryInfo(indexName,regionPath,queryString, defaultField,limit);
       return getSearchResults(queryInfo);
 
     }

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommands.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommands.java
@@ -346,9 +346,8 @@ public class LuceneIndexCommands extends AbstractCommandsSupport {
         case "n":
         {
           if (currentPage == totalPages) {
-            //at last page
             gfsh.printAsInfo("No more results to display.");
-            step = gfsh.interact("Press p to move to previous page and q to quit.");
+            step = gfsh.interact("Press p to move to last page and q to quit.");
             skipDisplay = true;
             continue;
           }
@@ -366,8 +365,8 @@ public class LuceneIndexCommands extends AbstractCommandsSupport {
         }
         case "p": {
           if (currentPage == 1) {
-            gfsh.printAsInfo("No more results to display.");
-            step = gfsh.interact("Press n to move to next page and q to quit.");
+            gfsh.printAsInfo("At the top of the search results.");
+            step = gfsh.interact("Press n to move to the first page and q to quit.");
             skipDisplay=true;
             continue;
           }

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneQueryInfo.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneQueryInfo.java
@@ -19,22 +19,27 @@ package com.gemstone.gemfire.cache.lucene.internal.cli;
 
 import java.io.Serializable;
 
+import com.gemstone.gemfire.cache.lucene.LuceneQueryFactory;
+
 public class LuceneQueryInfo implements Serializable {
   private static final long serialVersionUID = 1L;
   private String indexName;
   private String regionPath;
   private String queryString;
   private String defaultField;
+  private int limit;
 
   public LuceneQueryInfo(final String indexName,
                          final String regionPath,
                          final String queryString,
-                         final String defaultField)
+                         final String defaultField,
+                         final int limit)
   {
     this.indexName = indexName;
     this.regionPath = regionPath;
     this.queryString = queryString;
     this.defaultField = defaultField;
+    this.limit = limit;
   }
 
   public String getIndexName() {
@@ -52,4 +57,8 @@ public class LuceneQueryInfo implements Serializable {
   public String getDefaultField() {
     return defaultField;
   }
+
+  public int getLimit() {
+    if (limit == -1) return LuceneQueryFactory.DEFAULT_LIMIT;
+    else return limit; }
 }

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneSearchIndexFunction.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneSearchIndexFunction.java
@@ -71,8 +71,9 @@ public class LuceneSearchIndexFunction<K,V> extends FunctionAdapter implements I
     LuceneService luceneService = LuceneServiceProvider.get(getCache());
     try {
       if (cache.getRegion(queryInfo.getRegionPath())!=null) {
-        final LuceneQuery<K, V> query = luceneService.createLuceneQueryFactory().create(
-          queryInfo.getIndexName(), queryInfo.getRegionPath(), queryInfo.getQueryString(), queryInfo.getDefaultField());
+        final LuceneQuery<K, V> query = luceneService.createLuceneQueryFactory()
+          .setResultLimit(queryInfo.getLimit())
+          .create(queryInfo.getIndexName(), queryInfo.getRegionPath(), queryInfo.getQueryString(), queryInfo.getDefaultField());
         PageableLuceneQueryResults pageableLuceneQueryResults = query.findPages();
         while (pageableLuceneQueryResults.hasNext()) {
           List<LuceneResultStruct> page = pageableLuceneQueryResults.next();

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
@@ -346,6 +346,33 @@ public class LuceneIndexCommandsDUnitTest extends CliCommandTestBase {
     String resultAsString = executeCommandAndLogResult(csb);
     assertTrue(resultAsString.contains(LuceneCliStrings.LUCENE_SEARCH_INDEX__NO_RESULTS_MESSAGE));
   }
+
+  @Test
+  public void searchWithLimitShouldReturnCorrectResults() throws Exception {
+    final VM vm1 = Host.getHost(0).getVM(1);
+
+    createIndex(vm1);
+    Map<String,TestObject> entries=new HashMap<>();
+    entries.put("A",new TestObject("field1:value1 ","field2:value2","field3:value3"));
+    entries.put("B",new TestObject("ABC","EFG","HIJ"));
+    entries.put("C",new TestObject("field1:value1","QWE","RTY"));
+    entries.put("D",new TestObject("ABC","EFG","HIJ"));
+    entries.put("E",new TestObject("field1 :value1","ABC","EFG"));
+    entries.put("F",new TestObject("ABC","EFG","HIJ"));
+    entries.put("G",new TestObject("field1: value1","JKR","POW"));
+    entries.put("H",new TestObject("ABC","EFG","H2J"));
+    putEntries(vm1,entries,8);
+
+    CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_SEARCH_INDEX);
+    csb.addOption(LuceneCliStrings.LUCENE__INDEX_NAME,INDEX_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE__REGION_PATH,REGION_NAME);
+    csb.addOption(LuceneCliStrings.LUCENE_SEARCH_INDEX__QUERY_STRING,"field1:value1");
+    csb.addOption(LuceneCliStrings.LUCENE_SEARCH_INDEX__DEFAULT_FIELD,"field1");
+    csb.addOption(LuceneCliStrings.LUCENE_SEARCH_INDEX__LIMIT,"2");
+    TabularResultData data = (TabularResultData) executeCommandAndGetResult(csb).getResultData();
+    assertEquals(2,data.retrieveAllValues("key").size());
+  }
+
   private void createRegion() {
     getCache().createRegionFactory(RegionShortcut.PARTITION).create(REGION_NAME);
   }

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
@@ -318,6 +318,8 @@ public class LuceneIndexCommandsDUnitTest extends CliCommandTestBase {
     csb.addOption(LuceneCliStrings.LUCENE__REGION_PATH,REGION_NAME);
     csb.addOption(LuceneCliStrings.LUCENE_SEARCH_INDEX__QUERY_STRING,"field1:value1");
     csb.addOption(LuceneCliStrings.LUCENE_SEARCH_INDEX__DEFAULT_FIELD,"field1");
+    executeCommandAndLogResult(csb);
+
     TabularResultData data = (TabularResultData) executeCommandAndGetResult(csb).getResultData();
     assertEquals(4,data.retrieveAllValues("key").size());
   }
@@ -343,6 +345,8 @@ public class LuceneIndexCommandsDUnitTest extends CliCommandTestBase {
     csb.addOption(LuceneCliStrings.LUCENE__REGION_PATH,REGION_NAME);
     csb.addOption(LuceneCliStrings.LUCENE_SEARCH_INDEX__QUERY_STRING,"NotAnExistingValue");
     csb.addOption(LuceneCliStrings.LUCENE_SEARCH_INDEX__DEFAULT_FIELD,"field1");
+    executeCommandAndLogResult(csb);
+
     String resultAsString = executeCommandAndLogResult(csb);
     assertTrue(resultAsString.contains(LuceneCliStrings.LUCENE_SEARCH_INDEX__NO_RESULTS_MESSAGE));
   }
@@ -369,6 +373,7 @@ public class LuceneIndexCommandsDUnitTest extends CliCommandTestBase {
     csb.addOption(LuceneCliStrings.LUCENE_SEARCH_INDEX__QUERY_STRING,"field1:value1");
     csb.addOption(LuceneCliStrings.LUCENE_SEARCH_INDEX__DEFAULT_FIELD,"field1");
     csb.addOption(LuceneCliStrings.LUCENE_SEARCH_INDEX__LIMIT,"2");
+    executeCommandAndLogResult(csb);
     TabularResultData data = (TabularResultData) executeCommandAndGetResult(csb).getResultData();
     assertEquals(2,data.retrieveAllValues("key").size());
   }

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsJUnitTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsJUnitTest.java
@@ -225,7 +225,7 @@ public class LuceneIndexCommandsJUnitTest {
     doReturn(mockResultCollector).when(commands).executeFunctionOnGroups(isA(LuceneSearchIndexFunction.class),any(),any(LuceneQueryInfo.class));
     doReturn(queryResultsList).when(mockResultCollector).getResult();
 
-    CommandResult result = (CommandResult) commands.searchIndex("index","region","Result1","field1");
+    CommandResult result = (CommandResult) commands.searchIndex("index","region","Result1","field1",-1);
 
     TabularResultData data = (TabularResultData) result.getResultData();
 

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsJUnitTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsJUnitTest.java
@@ -297,7 +297,7 @@ public class LuceneIndexCommandsJUnitTest {
     assertEquals(expectedPage1,actualPageResults.get(15));
     assertEquals("\t\tPage 1 of 4",actualPageResults.get(16));
 
-    assertEquals("No more results to display.", actualPageResults.get(17));
+    assertEquals("At the top of the search results.", actualPageResults.get(17));
 
     assertEquals(expectedPage1,actualPageResults.get(18));
     assertEquals("\t\tPage 1 of 4",actualPageResults.get(19));

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneSearchIndexFunctionJUnitTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/functions/LuceneSearchIndexFunctionJUnitTest.java
@@ -54,7 +54,7 @@ public class LuceneSearchIndexFunctionJUnitTest {
     ResultSender resultSender = mock(ResultSender.class);
     GemFireCacheImpl cache = Fakes.cache();
 
-    LuceneQueryInfo queryInfo = createMockQueryInfo("index","region","field1:region1","field1");
+    LuceneQueryInfo queryInfo = createMockQueryInfo("index","region","field1:region1","field1",1);
     InternalLuceneService service = getMockLuceneService("A","Value","1.2");
     Region mockRegion=mock(Region.class);
 
@@ -81,7 +81,8 @@ public class LuceneSearchIndexFunctionJUnitTest {
   }
   private InternalLuceneService getMockLuceneService(String resultKey, String resultValue, String resultScore) throws LuceneQueryException{
     InternalLuceneService service=mock(InternalLuceneService.class);
-    LuceneQueryFactory mockQueryFactory = mock(LuceneQueryFactory.class);
+    LuceneQueryFactory mockQueryFactory = spy(LuceneQueryFactory.class);
+    LuceneQueryFactory mockQueryFactory2 = mock(LuceneQueryFactory.class);
     LuceneQuery mockQuery=mock(LuceneQuery.class);
     PageableLuceneQueryResults pageableLuceneQueryResults = mock(PageableLuceneQueryResults.class);
     LuceneResultStruct<String,String> resultStruct = new LuceneResultStructImpl(resultKey,resultValue,Float.valueOf(resultScore));
@@ -89,6 +90,7 @@ public class LuceneSearchIndexFunctionJUnitTest {
     queryResults.add(resultStruct);
 
     doReturn(mockQueryFactory).when(service).createLuceneQueryFactory();
+    doReturn(mockQueryFactory).when(mockQueryFactory).setResultLimit(anyInt());
     doReturn(mockQuery).when(mockQueryFactory).create(any(),any(),any(),any());
     when(mockQuery.findPages()).thenReturn(pageableLuceneQueryResults);
     when(pageableLuceneQueryResults.hasNext()).thenReturn(true).thenReturn(false);
@@ -97,12 +99,13 @@ public class LuceneSearchIndexFunctionJUnitTest {
     return service;
   }
 
-  private LuceneQueryInfo createMockQueryInfo(final String index, final String region, final String query, final String field) {
+  private LuceneQueryInfo createMockQueryInfo(final String index, final String region, final String query, final String field, final int limit) {
     LuceneQueryInfo queryInfo = mock(LuceneQueryInfo.class);
     when(queryInfo.getIndexName()).thenReturn(index);
     when(queryInfo.getRegionPath()).thenReturn(region);
     when(queryInfo.getQueryString()).thenReturn(query);
     when(queryInfo.getDefaultField()).thenReturn(field);
+    when(queryInfo.getLimit()).thenReturn(limit);
     return queryInfo;
   }
 


### PR DESCRIPTION
- Added limit option to the lucene search gfsh command to limit the number of search results to return.
- Added page size option to the lucene search gfsh command to paginate the search results.
- Added dunit and junit tests to verify the above.