### PR TITLE
Fixing lucene gfsh bugs

### DIFF
--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/LuceneServiceImpl.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/LuceneServiceImpl.java
@@ -143,6 +143,7 @@ public class LuceneServiceImpl implements InternalLuceneService {
 
     Region region = cache.getRegion(regionPath);
     if(region != null) {
+      definedIndexMap.remove(LuceneServiceImpl.getUniqueIndexName(indexName, regionPath));
       throw new IllegalStateException("The lucene index must be created before region");
     }
 

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneCliStrings.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneCliStrings.java
@@ -59,7 +59,7 @@ public class LuceneCliStrings {
 
   
   //Search lucene index commands
-  public static final String LUCENE_SEARCH_INDEX = "lucene search";
+  public static final String LUCENE_SEARCH_INDEX = "search lucene";
   public static final String LUCENE_SEARCH_INDEX__HELP = "Search lucene index";
   public static final String LUCENE_SEARCH_INDEX__ERROR_MESSAGE = "An error occurred while searching lucene index across the Geode cluster: %1$s";
   public static final String LUCENE_SEARCH_INDEX__NAME__HELP = "Name of the lucene index to search.";

--- a/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommands.java
+++ b/geode-lucene/src/main/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommands.java
@@ -243,6 +243,9 @@ public class LuceneIndexCommands extends AbstractCommandsSupport {
       SystemFailure.initiateFailure(e);
       throw e;
     }
+    catch (IllegalArgumentException e) {
+      return ResultBuilder.createInfoResult(e.getMessage());
+    }
     catch (Throwable t) {
       SystemFailure.checkFailure();
       getCache().getLogger().info(t);
@@ -310,6 +313,9 @@ public class LuceneIndexCommands extends AbstractCommandsSupport {
     catch (VirtualMachineError e) {
       SystemFailure.initiateFailure(e);
       throw e;
+    }
+    catch (IllegalArgumentException e) {
+      return ResultBuilder.createInfoResult(e.getMessage());
     }
     catch (Throwable t) {
       SystemFailure.checkFailure();
@@ -433,13 +439,13 @@ public class LuceneIndexCommands extends AbstractCommandsSupport {
 
   protected ResultCollector<?, ?> executeFunctionOnGroups(FunctionAdapter function,
                                                           String[] groups,
-                                                          final LuceneIndexInfo indexInfo) throws Exception
+                                                          final LuceneIndexInfo indexInfo) throws IllegalArgumentException, CommandResultException
   {
     final Set<DistributedMember> targetMembers;
     if (function != createIndexFunction) {
       targetMembers = CliUtil.getMembersForeRegionViaFunction(getCache(), indexInfo.getRegionPath());
       if (targetMembers.isEmpty()) {
-        throw new Exception("Region not found.");
+        throw new IllegalArgumentException("Region not found.");
       }
     }
     else {
@@ -451,7 +457,7 @@ public class LuceneIndexCommands extends AbstractCommandsSupport {
   protected ResultCollector<?, ?> executeSearch(final LuceneQueryInfo queryInfo) throws Exception {
     final Set<DistributedMember> targetMembers = CliUtil.getMembersForeRegionViaFunction(getCache(),queryInfo.getRegionPath());
     if (targetMembers.isEmpty())
-      throw new Exception("Region not found.");
+      throw new IllegalArgumentException("Region not found.");
     return CliUtil.executeFunction(searchIndexFunction, queryInfo, targetMembers);
   }
 }

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/LuceneIndexCreationIntegrationTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/LuceneIndexCreationIntegrationTest.java
@@ -213,6 +213,18 @@ public class LuceneIndexCreationIntegrationTest extends LuceneIntegrationTest {
                                                     .collect(Collectors.toList()));
   }
 
+  @Test
+  public void shouldRemoveDefinedIndexIfRegionAlreadyExists()
+  {
+    try {
+      createRegion();
+      createIndex("field1", "field2", "field3");
+
+    } catch(IllegalStateException e) {
+      assertEquals("The lucene index must be created before region", e.getMessage());
+      assertEquals(0,((LuceneServiceImpl) luceneService).getAllDefinedIndexes().size());
+    }
+  }
   private void verifyInternalRegions(Consumer<LocalRegion> verify) {
     LuceneTestUtilities.verifyInternalRegions(luceneService, cache, verify);
   }

--- a/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
+++ b/geode-lucene/src/test/java/com/gemstone/gemfire/cache/lucene/internal/cli/LuceneIndexCommandsDUnitTest.java
@@ -296,7 +296,7 @@ public class LuceneIndexCommandsDUnitTest extends CliCommandTestBase {
   }
 
   @Test
-  public void describeIndexWithoutRegionShouldReturnError() throws Exception {
+  public void describeIndexWithoutRegionShouldReturnErrorMessage() throws Exception {
 
     final VM vm1 = Host.getHost(0).getVM(1);
 
@@ -304,13 +304,7 @@ public class LuceneIndexCommandsDUnitTest extends CliCommandTestBase {
     CommandStringBuilder csb = new CommandStringBuilder(LuceneCliStrings.LUCENE_DESCRIBE_INDEX);
     csb.addOption(LuceneCliStrings.LUCENE__INDEX_NAME,"notAnIndex");
     csb.addOption(LuceneCliStrings.LUCENE__REGION_PATH,REGION_NAME);
-
-    String commandString = csb.toString();
-    writeToLog("Command String :\n ", commandString);
-    CommandResult commandResult = executeCommand(commandString);
-    String resultAsString = commandResultToString(commandResult);
-    writeToLog("Result String :\n ", resultAsString);
-    assertEquals(Status.ERROR, commandResult.getStatus());
+    String resultAsString = executeCommandAndLogResult(csb);
     assertTrue(resultAsString.contains("Region not found"));
   }
 
@@ -459,14 +453,8 @@ public class LuceneIndexCommandsDUnitTest extends CliCommandTestBase {
     csb.addOption(LuceneCliStrings.LUCENE_SEARCH_INDEX__QUERY_STRING, "EFG");
     csb.addOption(LuceneCliStrings.LUCENE_SEARCH_INDEX__DEFAULT_FIELD, "field2");
 
-    String commandString = csb.toString();
-    writeToLog("Command String :\n ", commandString);
-    CommandResult commandResult = executeCommand(commandString);
-    String resultAsString = commandResultToString(commandResult);
-    writeToLog("Result String :\n ", resultAsString);
-    assertEquals(Status.ERROR, commandResult.getStatus());
+    String resultAsString = executeCommandAndLogResult(csb);
     assertTrue(resultAsString.contains("Region not found"));
-
   }
 
   @Test


### PR DESCRIPTION
- If an index is created on an existing region, an exception is thrown, but the index is still stored in definedIndexMap. This is fixed by removing the index definition before the exception is thrown. Added a test to verify
- Previously, the describe/search index gfsh command on definied indexes returned an exception. Changed the behavior to return a message. Added dunit test to verify
- Changed Search index command to "search lucene" (previously "lucene search")
