### PR TITLE
GEODE-1128: Fixes for colocation configuration problems

### DIFF
--- a/geode-core/src/main/java/com/gemstone/gemfire/internal/cache/ColocationLogger.java
+++ b/geode-core/src/main/java/com/gemstone/gemfire/internal/cache/ColocationLogger.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.gemstone.gemfire.internal.cache;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+
+import com.gemstone.gemfire.CancelCriterion;
+import com.gemstone.gemfire.SystemFailure;
+import com.gemstone.gemfire.distributed.DistributedSystem;
+import com.gemstone.gemfire.internal.i18n.LocalizedStrings;
+import com.gemstone.gemfire.internal.logging.LogService;
+import com.gemstone.gemfire.internal.logging.log4j.LocalizedMessage;
+
+/**
+ * Provides logging when regions are missing from a colocation hierarchy. This logger runs in
+ * it's own thread and waits for child regions to be created before logging them as missing.
+ *
+ */
+public class ColocationLogger implements Runnable {
+  private static final Logger logger = LogService.getLogger();
+
+  private final PartitionedRegion region;
+  private final List<String> missingChildren = new ArrayList<String>();
+  private final Thread loggerThread;
+  private final Object loggerLock = new Object();
+
+  /**
+   * Sleep period (milliseconds) between posting log entries.
+   */
+  private static final int DEFAULT_LOG_INTERVAL = 30000;
+  private static int LOG_INTERVAL = DEFAULT_LOG_INTERVAL;
+
+  /**
+   * @param region the region that owns this logger instance
+   */
+  public ColocationLogger(PartitionedRegion region) {
+    this.region = region;
+    loggerThread = new Thread(this,"ColocationLogger for " + region.getName());
+    loggerThread.start();
+  }
+
+  public void run()
+  {
+    CancelCriterion stopper = region
+        .getGemFireCache().getDistributedSystem().getCancelCriterion();
+    DistributedSystem.setThreadsSocketPolicy(true /* conserve sockets */);
+    SystemFailure.checkFailure();
+    if (stopper.cancelInProgress() != null) {
+      return;
+    }
+    try {
+      run2();
+    } catch (VirtualMachineError err) {
+      SystemFailure.initiateFailure(err);
+      // If this ever returns, rethrow the error.  We're poisoned
+      // now, so don't let this thread continue.
+      throw err;
+    } catch (Throwable t) {
+      // Whenever you catch Error or Throwable, you must also
+      // catch VirtualMachineError (see above).  However, there is
+      // _still_ a possibility that you are dealing with a cascading
+      // error condition, so you also need to check to see if the JVM
+      // is still usable:
+      SystemFailure.checkFailure();
+      if (logger.isDebugEnabled()) {
+        logger.debug("Unexpected exception in colocation", t);
+      }
+    }
+  }
+
+  /**
+   * Writes a log entry every SLEEP_PERIOD when there are missing colocated child regions
+   * for this region.
+   * @throws InterruptedException
+   */
+  private void run2() throws InterruptedException {
+    boolean firstLogIteration = true;
+    synchronized(loggerLock) {
+      while (true) {
+        int sleepMillis = getLogInterval();
+        // delay for first log message is half the time of the interval between subsequent log messages
+        if (firstLogIteration) {
+          firstLogIteration = false;
+          sleepMillis /= 2;
+        }
+        loggerLock.wait(sleepMillis);
+        PRHARedundancyProvider rp = region.getRedundancyProvider();
+        if (rp != null && rp.isPersistentRecoveryComplete()) {
+          //Terminate the logging thread, recoverycomplete is only true when there are no missing colocated regions
+          break;
+        }
+        List<String>  existingRegions;
+        Map coloHierarchy = ColocationHelper.getAllColocationRegions(region);
+        missingChildren.removeAll(coloHierarchy.keySet());
+        if(missingChildren.isEmpty()) {
+          break;
+        }
+        logMissingRegions(region);
+      }
+    }
+  }
+
+  public void stopLogger() {
+    synchronized (loggerLock) {
+      missingChildren.clear();
+      loggerLock.notify();
+    }
+  }
+
+  public void addMissingChildRegion(String childFullPath) {
+    synchronized (loggerLock) {
+      if (!missingChildren.contains(childFullPath)) {
+        missingChildren.add(childFullPath);
+      }
+    }
+  }
+
+  public void addMissingChildRegions(PartitionedRegion childRegion) {
+    List<String> missingDescendants = childRegion.getMissingColocatedChildren();
+    for (String name:missingDescendants) {
+      addMissingChildRegion(name);
+    }
+  }
+
+  public List<String> getMissingChildRegions() {
+    return new ArrayList<String>(missingChildren);
+  }
+
+  /**
+   * Write the a logger warning for a PR that has colocated child regions that are missing.
+   * @param region the parent region that has missing child regions
+   */
+  private void logMissingRegions(PartitionedRegion region) {
+    String namesOfMissing = "";
+    if (!missingChildren.isEmpty()) {
+      namesOfMissing = String.join("\n\t", missingChildren);
+    }
+    String multipleChildren;
+    String singular = "";
+    String plural = "s";
+    multipleChildren = missingChildren.size() > 1 ? plural : singular;
+    namesOfMissing = String.join("\n\t", multipleChildren, namesOfMissing);
+    logger.warn(LocalizedMessage.create(LocalizedStrings.ColocationLogger_PERSISTENT_DATA_RECOVERY_OF_REGION_PREVENTED_BY_OFFLINE_COLOCATED_CHILDREN,
+        new Object[]{region.getFullPath(), namesOfMissing}));
+  }
+
+  public static int getLogInterval() {
+    return LOG_INTERVAL;
+  }
+
+  /*
+   * Test hook to allow unit test tests to run faster by tweak the interval between log messages
+   */
+  public synchronized static int testhookSetLogInterval(int sleepMillis) {
+    int currentSleep = LOG_INTERVAL;
+    LOG_INTERVAL = sleepMillis;
+    return currentSleep;
+  }
+  public synchronized static void testhookResetLogInterval() {
+    LOG_INTERVAL = DEFAULT_LOG_INTERVAL;
+  }
+}

--- a/geode-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionRegionConfig.java
+++ b/geode-core/src/main/java/com/gemstone/gemfire/internal/cache/PartitionRegionConfig.java
@@ -42,7 +42,7 @@ import com.gemstone.gemfire.internal.util.VersionedArrayList;
  * Maintains configuration information for a PartitionedRegion. Instances are
  * stored in the allPartitionedRegion.
  */
-public final class PartitionRegionConfig extends ExternalizableDSFID implements Versionable
+public class PartitionRegionConfig extends ExternalizableDSFID implements Versionable
 {
 
   /** PRId. */

--- a/geode-core/src/main/java/com/gemstone/gemfire/internal/i18n/LocalizedStrings.java
+++ b/geode-core/src/main/java/com/gemstone/gemfire/internal/i18n/LocalizedStrings.java
@@ -3770,6 +3770,9 @@ public class LocalizedStrings {
 
   public static final StringId AbstractDistributionConfig_SSL_ENABLED_COMPONENTS_SET_INVALID_DEPRECATED_SSL_SET = new StringId(6639,"When using ssl-enabled-components one cannot use any other SSL properties other than cluster-ssl-* or the corresponding aliases");
 
+  public static final StringId ColocationHelper_REGION_SPECIFIED_IN_COLOCATEDWITH_DOES_NOT_EXIST = new StringId(6640, "Region specified in ''colocated-with'' ({0}) for region {1} does not exist. It should be created before setting ''colocated-with'' attribute for this region.");
+  public static final StringId ColocationLogger_PERSISTENT_DATA_RECOVERY_OF_REGION_PREVENTED_BY_OFFLINE_COLOCATED_CHILDREN = new StringId(6641, "Persistent data recovery for region {0} is prevented by offline colocated region{1}");
+
   /** Testing strings, messageId 90000-99999 **/
   
   /** These are simple messages for testing, translated with Babelfish. **/

--- a/geode-core/src/test/java/com/gemstone/gemfire/internal/cache/ColocationHelperTest.java
+++ b/geode-core/src/test/java/com/gemstone/gemfire/internal/cache/ColocationHelperTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.gemstone.gemfire.internal.cache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.ArgumentCaptor;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LogEvent;
+
+import org.apache.logging.log4j.core.Logger;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import com.gemstone.gemfire.cache.PartitionAttributes;
+import com.gemstone.gemfire.cache.Region;
+import com.gemstone.gemfire.distributed.internal.InternalDistributedSystem;
+import com.gemstone.gemfire.test.fake.Fakes;
+import com.gemstone.gemfire.test.junit.categories.UnitTest;
+
+@Category(UnitTest.class)
+public class ColocationHelperTest {
+  private GemFireCacheImpl cache;
+  private GemFireCacheImpl oldCacheInstance;
+  private InternalDistributedSystem system;
+  private PartitionedRegion pr;
+  private DistributedRegion prRoot;
+  private PartitionAttributes pa;
+  private PartitionRegionConfig prc;
+  private Logger logger;
+  private Appender mockAppender;
+  private ArgumentCaptor<LogEvent> loggingEventCaptor;
+
+  /**
+   * @throws java.lang.Exception
+   */
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+  }
+
+  /**
+   * @throws java.lang.Exception
+   */
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+  }
+
+  /**
+   * @throws java.lang.Exception
+   */
+  @Before
+  public void setUp() throws Exception {
+    cache = Fakes.cache();
+    system = (InternalDistributedSystem) cache.getDistributedSystem();
+    pr = mock(PartitionedRegion.class);
+    prRoot = mock(DistributedRegion.class);
+    pa = mock(PartitionAttributes.class);
+    prc = mock(PartitionRegionConfig.class);
+    cache = Fakes.cache();
+    oldCacheInstance = GemFireCacheImpl.setInstanceForTests(cache);
+  }
+
+  /**
+   * @throws java.lang.Exception
+   */
+  @After
+  public void tearDown() throws Exception {
+    GemFireCacheImpl.setInstanceForTests(oldCacheInstance);
+  }
+
+  /**
+   * Test method for {@link com.gemstone.gemfire.internal.cache.ColocationHelper#getColocatedRegion(com.gemstone.gemfire.internal.cache.PartitionedRegion)}.
+   */
+  @Test
+  public void testGetColocatedRegionThrowsIllegalStateExceptionForMissingParentRegion() {
+    when(pr.getCache()).thenReturn(cache);
+    when(cache.getRegion(PartitionedRegionHelper.PR_ROOT_REGION_NAME, true)).thenReturn(mock(DistributedRegion.class));
+    when(pr.getPartitionAttributes()).thenReturn(pa);
+    when(pr.getFullPath()).thenReturn("/region1");
+    when(pa.getColocatedWith()).thenReturn("region2");
+
+    PartitionedRegion colocatedPR;
+    boolean caughtIllegalStateException = false;
+    try {
+      colocatedPR = ColocationHelper.getColocatedRegion(pr);
+    } catch (Exception e) {
+      assertEquals("Expected IllegalStateException for missing colocated parent region", IllegalStateException.class, e.getClass());
+      assertTrue("Expected IllegalStateException to be thrown for missing colocated region",
+          e.getMessage().matches("Region specified in 'colocated-with' .* does not exist.*"));
+      caughtIllegalStateException = true;
+    }
+    assertTrue(caughtIllegalStateException);
+  }
+
+  /**
+   * Test method for {@link com.gemstone.gemfire.internal.cache.ColocationHelper#getColocatedRegion(com.gemstone.gemfire.internal.cache.PartitionedRegion)}.
+   */
+  @Test
+  public void testGetColocatedRegionLogsWarningForMissingRegionWhenPRConfigHasRegion() {
+    when(pr.getCache()).thenReturn(cache);
+    when(cache.getRegion(PartitionedRegionHelper.PR_ROOT_REGION_NAME, true)).thenReturn(prRoot);
+    when(pr.getPartitionAttributes()).thenReturn(pa);
+    when(pr.getFullPath()).thenReturn("/region1");
+    when(pa.getColocatedWith()).thenReturn("region2");
+    when(((Region)prRoot).get("#region2")).thenReturn(prc);
+
+    PartitionedRegion colocatedPR = null;
+    boolean caughtIllegalStateException = false;
+    try {
+      colocatedPR = ColocationHelper.getColocatedRegion(pr);
+    } catch (Exception e) {
+      assertEquals("Expected IllegalStateException for missing colocated parent region", IllegalStateException.class, e.getClass());
+      assertTrue("Expected IllegalStateException to be thrown for missing colocated region",
+          e.getMessage().matches("Region specified in 'colocated-with' .* does not exist.*"));
+      caughtIllegalStateException = true;
+    }
+    assertTrue(caughtIllegalStateException);
+  }
+}

--- a/geode-core/src/test/java/com/gemstone/gemfire/internal/cache/partitioned/PersistentPartitionedRegionTestBase.java
+++ b/geode-core/src/test/java/com/gemstone/gemfire/internal/cache/partitioned/PersistentPartitionedRegionTestBase.java
@@ -239,10 +239,14 @@ public abstract class PersistentPartitionedRegionTestBase extends JUnit4CacheTes
   }
 
   protected void closePR(VM vm0) {
-    SerializableRunnable close = new SerializableRunnable("Close Cache") {
+    closePR(vm0, PR_REGION_NAME);
+  }
+
+  protected void closePR(VM vm0, String regionName) {
+    SerializableRunnable close = new SerializableRunnable("Close PR") {
       public void run() {
         Cache cache = getCache();
-        Region region = cache.getRegion(PR_REGION_NAME);
+        Region region = cache.getRegion(regionName);
         region.close();
       }
     };
@@ -251,10 +255,14 @@ public abstract class PersistentPartitionedRegionTestBase extends JUnit4CacheTes
   }
 
   protected void destroyPR(VM vm0) {
-    SerializableRunnable destroy = new SerializableRunnable() {
+    destroyPR(vm0,PR_REGION_NAME);
+  }
+
+  protected void destroyPR(VM vm0, String regionName) {
+    SerializableRunnable destroy = new SerializableRunnable("Destroy PR") {
       public void run() {
         Cache cache = getCache();
-        Region region = cache.getRegion(PR_REGION_NAME);
+        Region region = cache.getRegion(regionName);
         region.localDestroyRegion();
       }
     };
@@ -490,6 +498,7 @@ public abstract class PersistentPartitionedRegionTestBase extends JUnit4CacheTes
       }
     };
     
+    vm.invoke(getBuckets);
   }
   
   protected Set<Integer> getPrimaryBucketList(VM vm0) {


### PR DESCRIPTION
1) Test parent regions on child region creates and throw IllegalStateException
if parent region does not exist.
Missing parent regions were not being checked for, which resulted in NPE's getting thrown.

2) Log warnings when persistent colocated child regions don't exist.
Persistent data recovery cannot complete for any region in a colocation hierarchy if there are child regions that don't exist. The absence of any warning logs for this condition made it difficult to diagnose configuration problems.

3) Create Unit and DUnit tests for new exceptions and warnings