### PR TITLE
GEODE-1818: Bug37377DUnitTest passes with NPE suspect strings in log

### DIFF
--- a/geode-core/src/test/java/com/gemstone/gemfire/internal/cache/Bug37377DUnitTest.java
+++ b/geode-core/src/test/java/com/gemstone/gemfire/internal/cache/Bug37377DUnitTest.java
@@ -97,8 +97,6 @@ public class Bug37377DUnitTest extends JUnit4CacheTestCase
 
   /**
    * This method is used to create Cache in VM0
-   * 
-   * @return CacheSerializableRunnable
    */
 
   @SuppressWarnings("deprecation")
@@ -129,8 +127,6 @@ public class Bug37377DUnitTest extends JUnit4CacheTestCase
 
   /**
    * This method is used to create Cache in VM1
-   * 
-   * @return CacheSerializableRunnable
    */
   @SuppressWarnings("deprecation")
   private void createCacheForVM1() {
@@ -176,8 +172,6 @@ public class Bug37377DUnitTest extends JUnit4CacheTestCase
 
   /**
    * This method puts in maxEntries in the Region
-   * 
-   * @return CacheSerializableRunnable
    */
   private void putSomeEntries() {
     assertTrue("Cache is found as null ", cache != null);
@@ -191,7 +185,6 @@ public class Bug37377DUnitTest extends JUnit4CacheTestCase
    * This method clears the region and 
    * notifies the other member when complete
    * 
-   * @return CacheSerializableRunnable
    * @throws InterruptedException 
    */
   private static void invokeRemoteClearAndWait(VM remoteVM, VM thisVM) {

--- a/geode-core/src/test/java/com/gemstone/gemfire/internal/cache/Bug37377DUnitTest.java
+++ b/geode-core/src/test/java/com/gemstone/gemfire/internal/cache/Bug37377DUnitTest.java
@@ -22,32 +22,22 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 import com.gemstone.gemfire.test.dunit.cache.internal.JUnit4CacheTestCase;
-import com.gemstone.gemfire.test.dunit.internal.JUnit4DistributedTestCase;
 import com.gemstone.gemfire.test.junit.categories.DistributedTest;
 
 import java.io.File;
 import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
 
 import com.gemstone.gemfire.cache.AttributesFactory;
 import com.gemstone.gemfire.cache.Cache;
 import com.gemstone.gemfire.cache.CacheFactory;
 import com.gemstone.gemfire.cache.DataPolicy;
-import com.gemstone.gemfire.cache.EntryEvent;
-import com.gemstone.gemfire.cache.Operation;
 import com.gemstone.gemfire.cache.Region;
 import com.gemstone.gemfire.cache.RegionAttributes;
 import com.gemstone.gemfire.cache.Scope;
-import com.gemstone.gemfire.cache30.CacheSerializableRunnable;
-import com.gemstone.gemfire.cache30.CacheTestCase;
 import com.gemstone.gemfire.distributed.DistributedSystem;
-import com.gemstone.gemfire.internal.cache.lru.EnableLRU;
-import com.gemstone.gemfire.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
-import com.gemstone.gemfire.test.dunit.AsyncInvocation;
 import com.gemstone.gemfire.test.dunit.Host;
-import com.gemstone.gemfire.test.dunit.SerializableRunnable;
-import com.gemstone.gemfire.test.dunit.ThreadUtils;
 import com.gemstone.gemfire.test.dunit.VM;
-import com.gemstone.gemfire.test.dunit.Wait;
 
 /**
  * Bug37377 DUNIT Test: The Clear operation during a GII in progress can leave a
@@ -67,15 +57,17 @@ public class Bug37377DUnitTest extends JUnit4CacheTestCase
 
   protected static DistributedSystem distributedSystem = null;
 
-  private static VM vm0 = null;
-
-  private static VM vm1 = null;
+  VM vm0, vm1;
 
   protected static Cache cache = null;
 
   protected static File[] dirs = null;
 
   private static final int maxEntries = 10000;
+
+  transient private static CountDownLatch clearLatch = new CountDownLatch(1);
+
+  static Boolean clearOccured = false;
 
   public Bug37377DUnitTest() {
     super();
@@ -99,8 +91,8 @@ public class Bug37377DUnitTest extends JUnit4CacheTestCase
 
   @Override
   public final void preTearDownCacheTestCase() throws Exception {
-    vm1.invoke(destroyRegion());
-    vm0.invoke(destroyRegion());
+    vm1.invoke(() -> destroyRegion());
+    vm0.invoke(() -> destroyRegion());
   }
 
   /**
@@ -109,37 +101,30 @@ public class Bug37377DUnitTest extends JUnit4CacheTestCase
    * @return CacheSerializableRunnable
    */
 
-  private CacheSerializableRunnable createCacheForVM0()
-  {
-    SerializableRunnable createCache = new CacheSerializableRunnable(
-        "createCache") {
-      public void run2()
-      {
-        try {
+  @SuppressWarnings("deprecation")
+  private void createCacheForVM0() {
+    try {
 
-          distributedSystem = (new Bug37377DUnitTest())
-              .getSystem(props);
-          assertTrue(distributedSystem != null);
-          cache = CacheFactory.create(distributedSystem);
-          assertTrue(cache != null);
-          AttributesFactory factory = new AttributesFactory();
-          factory.setScope(Scope.DISTRIBUTED_ACK);
-          factory.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
-          factory.setDiskSynchronous(false);
-          factory.setDiskStoreName(cache.createDiskStoreFactory()
-                                   .setDiskDirs(dirs)
-                                   .create("Bug37377DUnitTest")
-                                   .getName());
-          RegionAttributes attr = factory.create();
-          cache.createRegion(regionName, attr);
-        }
-        catch (Exception ex) {
-          ex.printStackTrace();
-          fail("Error Creating cache / region ");
-        }
-      }
-    };
-    return (CacheSerializableRunnable)createCache;
+      distributedSystem = (new Bug37377DUnitTest())
+          .getSystem(props);
+      assertTrue(distributedSystem != null);
+      cache = CacheFactory.create(distributedSystem);
+      assertTrue(cache != null);
+      AttributesFactory factory = new AttributesFactory();
+      factory.setScope(Scope.DISTRIBUTED_ACK);
+      factory.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
+      factory.setDiskSynchronous(false);
+      factory.setDiskStoreName(cache.createDiskStoreFactory()
+          .setDiskDirs(dirs)
+          .create("Bug37377DUnitTest")
+          .getName());
+      RegionAttributes attr = factory.create();
+      cache.createRegion(regionName, attr);
+    }
+    catch (Exception ex) {
+      ex.printStackTrace();
+      fail("Error Creating cache / region ");
+    }
   }
 
   /**
@@ -147,51 +132,46 @@ public class Bug37377DUnitTest extends JUnit4CacheTestCase
    * 
    * @return CacheSerializableRunnable
    */
-  private CacheSerializableRunnable createCacheForVM1()
-  {
-    SerializableRunnable createCache = new CacheSerializableRunnable(
-        "createCache") {
-      public void run2()
-      {
-        try {
-          distributedSystem = (new Bug37377DUnitTest())
-              .getSystem(props);
-          assertTrue(distributedSystem != null);
-          cache = CacheFactory.create(distributedSystem);
-          assertTrue("cache found null", cache != null);
+  @SuppressWarnings("deprecation")
+  private void createCacheForVM1() {
+    try {
+      distributedSystem = (new Bug37377DUnitTest())
+          .getSystem(props);
+      assertTrue(distributedSystem != null);
+      cache = CacheFactory.create(distributedSystem);
+      assertTrue("cache found null", cache != null);
 
-          AttributesFactory factory = new AttributesFactory();
-          factory.setScope(Scope.DISTRIBUTED_ACK);
-          factory.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
-          factory.setDiskSynchronous(false);
-          factory.setDiskStoreName(cache.createDiskStoreFactory()
-                                   .setDiskDirs(dirs)
-                                   .create("Bug37377DUnitTest")
-                                   .getName());
-          RegionAttributes attr = factory.create();
-          DistributedRegion distRegion = new DistributedRegion(regionName,
-              attr, null, (GemFireCacheImpl)cache, new InternalRegionArguments()
-                  .setDestroyLockFlag(true).setRecreateFlag(false)
-                  .setSnapshotInputStream(null).setImageTarget(null));
-//          assertTrue("Distributed Region is null", distRegion != null); (cannot be null)
+      AttributesFactory factory = new AttributesFactory();
+      factory.setScope(Scope.DISTRIBUTED_ACK);
+      factory.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
+      factory.setDiskSynchronous(false);
+      factory.setDiskStoreName(cache.createDiskStoreFactory()
+          .setDiskDirs(dirs)
+          .create("Bug37377DUnitTest")
+          .getName());
+      RegionAttributes attr = factory.create();
+      DistributedRegion distRegion = new DistributedRegion(regionName,
+          attr, null, (GemFireCacheImpl)cache, new InternalRegionArguments()
+          .setDestroyLockFlag(true).setRecreateFlag(false)
+          .setSnapshotInputStream(null).setImageTarget(null));
+      //      assertTrue("Distributed Region is null", distRegion != null); (cannot be null)
 
-          ((AbstractRegionMap)distRegion.entries)
-              .setEntryFactory(TestAbstractDiskRegionEntry.getEntryFactory());
+      TestAbstractDiskRegionEntry.setMembers(vm1, vm0);    // vm1 is thisVM, vm0 is otherVM
 
-          LocalRegion region = (LocalRegion)((GemFireCacheImpl)cache)
-              .createVMRegion(regionName, attr, new InternalRegionArguments()
-                  .setInternalMetaRegion(distRegion).setDestroyLockFlag(true)
-                  .setSnapshotInputStream(null).setImageTarget(null));
-          assertTrue("Local Region is null", region != null);
+      ((AbstractRegionMap)distRegion.entries)
+      .setEntryFactory(TestAbstractDiskRegionEntry.getEntryFactory());
 
-        }
-        catch (Exception ex) {
-          ex.printStackTrace();
-          fail("Error Creating cache / region " + ex);
-        }
-      }
-    };
-    return (CacheSerializableRunnable)createCache;
+      LocalRegion region = (LocalRegion)((GemFireCacheImpl)cache)
+          .createVMRegion(regionName, attr, new InternalRegionArguments()
+              .setInternalMetaRegion(distRegion).setDestroyLockFlag(true)
+              .setSnapshotInputStream(null).setImageTarget(null));
+      assertTrue("Local Region is null", region != null);
+
+    }
+    catch (Exception ex) {
+      ex.printStackTrace();
+      fail("Error Creating cache / region " + ex);
+    }  
   }
 
   /**
@@ -199,106 +179,80 @@ public class Bug37377DUnitTest extends JUnit4CacheTestCase
    * 
    * @return CacheSerializableRunnable
    */
-  private CacheSerializableRunnable putSomeEntries()
-  {
-    SerializableRunnable puts = new CacheSerializableRunnable("putSomeEntries") {
-      public void run2()
-      {
-        assertTrue("Cache is found as null ", cache != null);
-        Region rgn = cache.getRegion(regionName);
-        for (int i = 0; i < maxEntries; i++) {
-          rgn.put(new Long(i), new Long(i));
-        }
-      }
-    };
-    return (CacheSerializableRunnable)puts;
+  private void putSomeEntries() {
+    assertTrue("Cache is found as null ", cache != null);
+    Region rgn = cache.getRegion(regionName);
+    for (int i = 0; i < maxEntries; i++) {
+      rgn.put(new Long(i), new Long(i));
+    }
+  }
+
+  /**
+   * This method clears the region and 
+   * notifies the other member when complete
+   * 
+   * @return CacheSerializableRunnable
+   * @throws InterruptedException 
+   */
+  private static void invokeRemoteClearAndWait(VM remoteVM, VM thisVM) {
+    remoteVM.invoke(() -> clearRegionAndNotify(thisVM));
+    try {
+      clearLatch.await();
+    } catch (InterruptedException e) {
+      fail("wait for remote clear to complete failed");
+    }
+  }
+
+  /**
+   * This method clears the region and 
+   * notifies the other member when complete
+   */
+  private static void clearRegionAndNotify(VM otherVM) {
+    assertTrue("Cache is found as null ", cache != null);
+    Region rgn = cache.getRegion(regionName);
+    rgn.clear();
+    otherVM.invoke(() -> notifyClearComplete());
+  }
+
+  /**
+   * Decrement countdown latch to notify clear complete 
+   */
+  private static void notifyClearComplete() {
+    clearLatch.countDown();
   }
 
   /**
    * This method destroys the Region
-   * 
-   * @return CacheSerializableRunnable
    */
-  private CacheSerializableRunnable destroyRegion()
-  {
-    SerializableRunnable puts = new CacheSerializableRunnable("destroyRegion") {
-      public void run2()
-      {
-        try {
-          assertTrue("Cache is found as null ", cache != null);
-
-          Region rgn = cache.getRegion(regionName);
-          rgn.localDestroyRegion();
-          cache.close();
-        }
-        catch (Exception ex) {
-
-        }
-      }
-    };
-    return (CacheSerializableRunnable)puts;
+  private void destroyRegion() {
+    try {
+      assertTrue("Cache is found as null ", cache != null);
+      Region rgn = cache.getRegion(regionName);
+      rgn.localDestroyRegion();
+      cache.close();
+    }
+    catch (Exception ex) {}
   }
 
   /**
-   * This method is used to close cache on the calling VM
-   * 
-   * @return CacheSerializableRunnable
+   * This method closes the cache on the specified VM
    */
-  private CacheSerializableRunnable closeCacheForVM(final int vmNo)
-  {
-    SerializableRunnable cclose = new CacheSerializableRunnable(
-        "closeCacheForVM") {
-      public void run2()
-      {
-        if (vmNo == 0) {
-          cache.getRegion(regionName).localDestroyRegion();
-        }
-        assertTrue("Cache is found as null ", cache != null);
-        cache.close();
-      }
-    };
-    return (CacheSerializableRunnable)cclose;
+  private void closeCacheForVM(final int vmNo) {
+    if (vmNo == 0) {
+      cache.getRegion(regionName).localDestroyRegion();
+    }
+    assertTrue("Cache is found as null ", cache != null);
+    cache.close();
   }
-
+ 
   /**
-   * This method is used to close cache on the calling VM
-   * 
-   * @return CacheSerializableRunnable
+   * This method verifies that the reintialized region size is zero
    */
-  private CacheSerializableRunnable closeCacheInVM()
-  {
-    SerializableRunnable cclose = new CacheSerializableRunnable(
-        "closeCacheInVM") {
-      public void run2()
-      {
-
-        cache.getRegion(regionName).localDestroyRegion();
-        assertTrue("Cache is found as null ", cache != null);
-        cache.close();
-      }
-    };
-    return (CacheSerializableRunnable)cclose;
-  }
-
-  /**
-   * This method verifies that the reintialized region size should be zero
-   * 
-   * @return CacheSerializableRunnable
-   */
-  private CacheSerializableRunnable verifyExtraEntryFromOpLogs()
-  {
-    SerializableRunnable verify = new CacheSerializableRunnable(
-        "verifyExtraEntryFromOpLogs") {
-      public void run2()
-      {
-        assertTrue("Cache is found as null ", cache != null);
-        Region rgn = cache.getRegion(regionName);
-        // should be zero after reinit
-        assertEquals(0, rgn.size());
-      }
-    };
-    return (CacheSerializableRunnable)verify;
-
+  private void verifyExtraEntryFromOpLogs() {
+    assertTrue("Cache is found as null ", cache != null);
+    Region rgn = cache.getRegion(regionName);
+    // should be zero after clear
+    assertEquals(0, rgn.size());
   }
 
   /**
@@ -309,44 +263,45 @@ public class Bug37377DUnitTest extends JUnit4CacheTestCase
    */
 
   @Test
-  public void testGIIputWithClear()
-  {
-    vm0.invoke(createCacheForVM0());
-    vm0.invoke(putSomeEntries());
-    AsyncInvocation as1 = vm1.invokeAsync(createCacheForVM1());
-    Wait.pause(10000);
-    ThreadUtils.join(as1, 30 * 1000);
-    vm0.invoke(closeCacheForVM(0));
-    vm1.invoke(closeCacheForVM(1));
-    vm1.invoke(createCacheForVM1());
-    vm1.invoke(verifyExtraEntryFromOpLogs());
+  public void testGIIputWithClear() {
+    vm0.invoke(() -> createCacheForVM0());
+    vm0.invoke(() -> putSomeEntries());
+
+    vm1.invoke(() -> createCacheForVM1());
+
+    vm0.invoke(() -> closeCacheForVM(0));
+    vm1.invoke(() -> closeCacheForVM(1));
+
+    vm1.invoke(() -> createCacheForVM1());
+    vm1.invoke(() -> verifyExtraEntryFromOpLogs());
   }
 
-  static class TestAbstractDiskRegionEntry extends VMThinDiskRegionEntryHeapObjectKey
-  {
-    protected TestAbstractDiskRegionEntry(RegionEntryContext r, Object key,
-        Object value) {
+  static class TestAbstractDiskRegionEntry extends VersionedThinDiskRegionEntryHeapObjectKey {
+    static private VM thisVM, otherVM;
+
+    static void setMembers(VM localVM, VM remoteVM) {
+      thisVM = localVM;
+      otherVM = remoteVM;
+    }
+
+    protected TestAbstractDiskRegionEntry(RegionEntryContext r, Object key, Object value) {
       super(r, key, value);
     }
-    
-    private static RegionEntryFactory factory = new RegionEntryFactory() {
-      public final RegionEntry createEntry(RegionEntryContext r, Object key,
-          Object value)
-      {
 
+    private static RegionEntryFactory factory = new RegionEntryFactory() {
+      
+      public final RegionEntry createEntry(RegionEntryContext r, Object key, Object value) {
         return new TestAbstractDiskRegionEntry(r, key, value);
       }
 
-      public final Class getEntryClass()
-      {
-
+      public final Class getEntryClass() {
         return TestAbstractDiskRegionEntry.class;
       }
 
       public RegionEntryFactory makeVersioned() {
         return this;
       }
-      
+
       public RegionEntryFactory makeOnHeap() {
         return this;
       }
@@ -358,24 +313,35 @@ public class Bug37377DUnitTest extends JUnit4CacheTestCase
      */
     @Override
     public boolean initialImageInit(final LocalRegion r,
-                                    final long lastModifiedTime,
-                                    final Object newValue,
-                                    final boolean create,
-                                    final boolean wasRecovered,
-                                    final boolean versionTagAccepted) throws RegionClearedException
+        final long lastModifiedTime,
+        final Object newValue,
+        final boolean create,
+        final boolean wasRecovered,
+        final boolean versionTagAccepted) throws RegionClearedException
     {
-      RegionEventImpl event = new RegionEventImpl(r, Operation.REGION_CLEAR,
-                                                  null, true /* isOriginRemote */,
-                                                  r.cache.getMyId());
-      ((DistributedRegion)r).cmnClearRegion(event, false, false);
-      boolean result = super.initialImageInit(r, lastModifiedTime, newValue, create, wasRecovered, versionTagAccepted);
-      fail("expected RegionClearedException");
-      return result;
+      synchronized(clearOccured) {
+        if(!clearOccured) {
+          // Force other member to perform a clear during our GII
+          invokeRemoteClearAndWait(otherVM, thisVM);
+          clearOccured = true;
+        }
+      }
+
+      // Continue GII processing, which should throw RegionClearedException after the clear
+      try {
+        boolean result = super.initialImageInit(r, lastModifiedTime, newValue, create, wasRecovered, versionTagAccepted);
+      } catch (RegionClearedException rce) {
+        throw rce;
+      } catch (Exception ex) {
+        fail("Caught exception during initialImageInit: " + ex );
+      }
+
+      return true;
     }
 
-    public static RegionEntryFactory getEntryFactory()
-    {
+    public static RegionEntryFactory getEntryFactory() {
       return factory;
     }
   }
 }
+


### PR DESCRIPTION
This is an older test which had experienced some severe "code rot".

Modified code to conform to current product behavior.
Removed use of internal APIs and dummy remote clear event from test.
Updated remote method execution to utilize new lambda technique.