### PR TITLE
GEODE-1905: Address UnknownPropertyException when running tests with Gradle 3.0+

### DIFF
--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -14,15 +14,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import org.apache.mina.util.AvailablePortFinder as MinaAvailablePortFinder
+
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+
+  dependencies {
+    classpath group: 'org.apache.mina', name: 'mina-core', version: '2.0.14'
+  }
+}
+
 def testResultsDir(def parent, def name) {
   new File(parent, name)
 }
 
 def writeTestProperties(def parent, def name) {
-  def availablePortFinder = AvailablePortFinder.createPrivate()
-  
   def props = new Properties()
-  props.setProperty('mcast-port', Integer.toString(availablePortFinder.nextAvailable))
+  props.setProperty('mcast-port', Integer.toString(MinaAvailablePortFinder.getNextAvailable()))
   props.setProperty('log-level', 'config')
   def propsFile = new File(testResultsDir(parent, name), 'gemfire.properties')
   def writer = propsFile.newWriter()
@@ -61,7 +71,7 @@ subprojects {
     testCompile 'org.jmock:jmock-junit4:' + project.'jmock.version'
     testCompile 'org.jmock:jmock-legacy:' + project.'jmock.version'
     testCompile 'pl.pragmatists:JUnitParams:' + project.'JUnitParams.version'
-    
+
     testRuntime 'cglib:cglib:' + project.'cglib.version'
     testRuntime 'org.ow2.asm:asm:' + project.'asm.version'
   }


### PR DESCRIPTION
AvailablePortFinder was deprecated in [Gradle 2.8](https://docs.gradle.org/2.8/release-notes#deprecated-classes-and-constants) and removed in Gradle 3.0.  

I took a look into how the Gradle project itself dealt with this change, and they [use]( https://github.com/gradle/gradle/blob/2703311c33e8a295ba7ccb29a62ed8be761ef66f/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/HonestProfilerCollector.groovy)  the Apache MINA library's [org.apache.mina.util.AvailablePortFinder](https://mina.apache.org/mina-project/apidocs/src-html/org/apache/mina/util/AvailablePortFinder.html) class.