### PR TITLE
Marked test guaranteed to take at least 1 minute as an integration test

### DIFF
--- a/extensions/geode-modules-tomcat7/src/test/java/org/apache/geode/modules/session/Tomcat7SessionsJUnitTest.java
+++ b/extensions/geode-modules-tomcat7/src/test/java/org/apache/geode/modules/session/Tomcat7SessionsJUnitTest.java
@@ -19,7 +19,7 @@ package org.apache.geode.modules.session;
 import static org.junit.Assert.assertEquals;
 
 import org.apache.geode.modules.session.catalina.Tomcat7DeltaSessionManager;
-import org.apache.geode.test.junit.categories.UnitTest;
+import org.apache.geode.test.junit.categories.IntegrationTest;
 
 import com.meterware.httpunit.GetMethodWebRequest;
 import com.meterware.httpunit.WebConversation;
@@ -29,7 +29,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-@Category(UnitTest.class)
+@Category(IntegrationTest.class)
 public class Tomcat7SessionsJUnitTest extends TestSessionsBase {
 
   // Set up the session manager we need


### PR DESCRIPTION
This test is guaranteed to take at least 65 seconds to run.  Our [wiki](https://cwiki.apache.org/confluence/display/GEODE/Writing+tests) says that UnitTests should run in milliseconds.  I have marked it as an IntegrationTest to speed up our builds.