### PR TITLE
GEODE-1983: Swagger is broken with integrated security

### DIFF
--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/security/RestSecurityConfiguration.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/security/RestSecurityConfiguration.java
@@ -17,8 +17,6 @@
  */
 package org.apache.geode.rest.internal.web.security;
 
-import org.apache.geode.internal.security.IntegratedSecurityService;
-import org.apache.geode.internal.security.SecurityService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -30,6 +28,9 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+
+import org.apache.geode.internal.security.IntegratedSecurityService;
+import org.apache.geode.internal.security.SecurityService;
 
 @Configuration
 @EnableWebSecurity
@@ -56,8 +57,7 @@ public class RestSecurityConfiguration extends WebSecurityConfigurerAdapter {
   protected void configure(HttpSecurity http) throws Exception {
     http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
         .and()
-        .authorizeRequests()
-        .antMatchers("/ping").permitAll()
+        .authorizeRequests().antMatchers("/ping", "/api-docs/**", "/docs/**").permitAll()
         .anyRequest().authenticated()
         .and()
         .formLogin()


### PR DESCRIPTION
This required a simple configuration change.  The swagger endpoints needed to be marked as permitAll so that the resources could be read.