### PR TITLE
GEODE-1098: Fix gfsh.bat error with default Java installation

### DIFF
--- a/geode-assembly/src/main/dist/bin/gfsh.bat
+++ b/geode-assembly/src/main/dist/bin/gfsh.bat
@@ -82,5 +82,5 @@ REM  Expect to find the tools.jar from the JDK
 )
 
 REM Call java with our classpath
-@"%GF_JAVA%" -Dgfsh=true -Dlog4j.configurationFile=classpath:log4j2-cli.xml -classpath %DEPENDENCIES% %JAVA_ARGS% %LAUNCHER% %*
+@"%GF_JAVA%" -Dgfsh=true -Dlog4j.configurationFile=classpath:log4j2-cli.xml -classpath "%DEPENDENCIES%" %JAVA_ARGS% %LAUNCHER% %*
 :done


### PR DESCRIPTION
Paths to JAR dependencies quoted to prevent spaces from causing error
