### PR TITLE
GEODE-2084 - When executing a rest api in a browser, the login page p…

### DIFF
--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/security/RestSecurityConfiguration.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/security/RestSecurityConfiguration.java
@@ -56,7 +56,7 @@ public class RestSecurityConfiguration extends WebSecurityConfigurerAdapter {
         .authorizeRequests()
         .antMatchers("/ping", "/docs/**", "/swagger-ui.html", "/v2/api-docs/**",
             "/webjars/springfox-swagger-ui/**", "/swagger-resources/**")
-        .permitAll().anyRequest().authenticated().and().formLogin().and().csrf().disable();
+        .permitAll().anyRequest().authenticated().and().csrf().disable();
 
     if (securityService.isIntegratedSecurity()) {
       http.httpBasic();


### PR DESCRIPTION
…resented in the browser is not setting the username/password correctly

Changed RestSecurityConfiguration to not call login(), which will bring up the browsers Authentication dialog instead.