### PR TITLE
GEODE-2098: Moved gfsh history file location from .gemfire to .geode

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/shell/GfshConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/shell/GfshConfig.java
@@ -201,7 +201,7 @@ public class GfshConfig {
 
   private static String getHomeGemFireDirectory() {
     String userHome = System.getProperty("user.home");
-    String homeDirPath = userHome + "/.gemfire";
+    String homeDirPath = userHome + "/.geode";
     File alternateDir = new File(homeDirPath);
     if (!alternateDir.exists()) {
       if (!alternateDir.mkdirs()) {

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/shell/GfshConfigInitFileJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/shell/GfshConfigInitFileJUnitTest.java
@@ -26,6 +26,8 @@ import org.junit.rules.TemporaryFolder;
 
 import org.apache.geode.test.junit.categories.IntegrationTest;
 
+import java.io.File;
+
 @Category(IntegrationTest.class)
 public class GfshConfigInitFileJUnitTest {
 
@@ -167,4 +169,9 @@ public class GfshConfigInitFileJUnitTest {
     assertNull(result);
   }
 
+  @Test
+  public void historyFileLocationTest() throws Exception {
+    GfshConfig gfshConfig = new GfshConfig();
+    assertEquals(".geode", (new File(gfshConfig.getHistoryFileName())).getParentFile().getName());
+  }
 }


### PR DESCRIPTION
Made the code changes and added a test for the same.

Following Test is failing with precheckin, but works fine when ran individually.
org.apache.geode.internal.statistics.DiskSpaceLimitIntegrationTest 