### PR TITLE
GEODE-2117: Pulse handles float type mbean attributes

### DIFF
--- a/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/data/JMXDataUpdater.java
+++ b/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/data/JMXDataUpdater.java
@@ -47,6 +47,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.management.ManagementFactory;
+import java.math.BigDecimal;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -65,8 +66,7 @@ import java.util.Set;
 
 /**
  * Class JMXDataUpdater Class used for creating JMX connection and getting all the required MBeans
- *
- *
+ * 
  * @since GemFire version 7.0.Beta 2012-09-23
  */
 public class JMXDataUpdater implements IClusterUpdater, NotificationListener {
@@ -261,8 +261,9 @@ public class JMXDataUpdater implements IClusterUpdater, NotificationListener {
         connection = JMXConnectorFactory.connect(url, env);
 
         // Register Pulse URL if not already present in the JMX Manager
-        if (registerURL)
+        if (registerURL) {
           registerPulseUrlToManager(connection);
+        }
       }
     } catch (Exception e) {
       if (e instanceof UnknownHostException) {
@@ -567,10 +568,8 @@ public class JMXDataUpdater implements IClusterUpdater, NotificationListener {
 
   /**
    * function used to get attribute values of Cluster System and map them to cluster vo
-   *
+   * 
    * @param mbeanName Cluster System MBean
-   * @throws IOException
-   *
    */
   private void updateClusterSystem(ObjectName mbeanName) throws IOException {
     try {
@@ -787,17 +786,8 @@ public class JMXDataUpdater implements IClusterUpdater, NotificationListener {
   /**
    * function used to get attribute values of Gateway Receiver and map them to GatewayReceiver inner
    * class object
-   *
-   * @param mbeanName
+   * 
    * @return GatewayReceiver object
-   * @throws InstanceNotFoundException
-   * @throws IntrospectionException
-   * @throws ReflectionException
-   * @throws IOException
-   * @throws AttributeNotFoundException
-   * @throws MBeanException
-   *
-   *
    */
   private Cluster.GatewayReceiver initGatewayReceiver(ObjectName mbeanName)
       throws InstanceNotFoundException, IntrospectionException, ReflectionException, IOException,
@@ -831,15 +821,6 @@ public class JMXDataUpdater implements IClusterUpdater, NotificationListener {
   /**
    * function used to get attribute values of Gateway Sender and map them to GatewaySender inner
    * class object
-   *
-   * @param mbeanName
-   * @return
-   * @throws InstanceNotFoundException
-   * @throws IntrospectionException
-   * @throws ReflectionException
-   * @throws IOException
-   * @throws AttributeNotFoundException
-   * @throws MBeanException
    */
   private Cluster.GatewaySender initGatewaySender(ObjectName mbeanName)
       throws InstanceNotFoundException, IntrospectionException, ReflectionException, IOException,
@@ -943,15 +924,6 @@ public class JMXDataUpdater implements IClusterUpdater, NotificationListener {
   /**
    * function used to get attribute values of Async Event Queue and map them to Async Event Queue
    * inner class object
-   *
-   * @param mbeanName
-   * @return
-   * @throws InstanceNotFoundException
-   * @throws IntrospectionException
-   * @throws ReflectionException
-   * @throws IOException
-   * @throws AttributeNotFoundException
-   * @throws MBeanException
    */
   private Cluster.AsyncEventQueue initAsyncEventQueue(ObjectName mbeanName)
       throws InstanceNotFoundException, IntrospectionException, ReflectionException, IOException,
@@ -1168,10 +1140,9 @@ public class JMXDataUpdater implements IClusterUpdater, NotificationListener {
 
   /**
    * Add member specific region information on the region
-   *
+   * 
    * @param regionObjectName: used to construct the jmx objectname. For region name that has special
    *        characters in, it will have double quotes around it.
-   * @param region
    */
   private void updateRegionOnMembers(String regionObjectName, String regionFullPath,
       Cluster.Region region) throws IOException {
@@ -1350,7 +1321,7 @@ public class JMXDataUpdater implements IClusterUpdater, NotificationListener {
 
   /**
    * function used to get attribute values of Cluster Region and map them to cluster region vo
-   *
+   * 
    * @param mbeanName Cluster Region MBean
    */
   private void updateClusterRegion(ObjectName mbeanName) throws IOException {
@@ -1767,7 +1738,7 @@ public class JMXDataUpdater implements IClusterUpdater, NotificationListener {
 
   /**
    * function used to get attribute values of Cluster Member and map them to cluster member vo
-   *
+   * 
    * @param mbeanName Cluster Member MBean
    */
   private void updateClusterMember(ObjectName mbeanName) throws IOException {
@@ -1950,25 +1921,27 @@ public class JMXDataUpdater implements IClusterUpdater, NotificationListener {
    * function used to handle Double data type if the value for mbean for an attribute is null then
    * return 0.0 as default value else return the attribute value
    */
-  private Double getDoubleAttribute(Object object, String name) {
+  Double getDoubleAttribute(Object object, String name) {
     if (object == null) {
       return Double.valueOf(0);
     }
 
     try {
-      if (!(object.getClass().equals(Double.class))) {
+      if (object instanceof Float) {
+        return BigDecimal.valueOf((Float) object).doubleValue();
+      } else if (object instanceof Double) {
+        return (Double) object;
+      } else {
         if (LOGGER.infoEnabled()) {
           LOGGER.info("************************Unexpected type for attribute: " + name
               + " Expected type: " + Double.class.getName() + " Received type: "
               + object.getClass().getName() + "************************");
         }
         return Double.valueOf(0);
-      } else {
-        return (Double) object;
       }
     } catch (Exception e) {
       if (LOGGER.infoEnabled()) {
-        LOGGER.info("Exception occurred: " + e.getMessage());
+        LOGGER.info("Exception occurred: ", e);
       }
       return Double.valueOf(0);
     }
@@ -1976,7 +1949,7 @@ public class JMXDataUpdater implements IClusterUpdater, NotificationListener {
 
   /**
    * function used to get attribute values of Member Region and map them to Member vo
-   *
+   * 
    * @param mbeanName Member Region MBean
    */
   private void updateMemberRegion(ObjectName mbeanName) throws IOException {

--- a/geode-pulse/src/test/java/org/apache/geode/tools/pulse/internal/data/JMXDataUpdaterGetDoubleAttributeTest.java
+++ b/geode-pulse/src/test/java/org/apache/geode/tools/pulse/internal/data/JMXDataUpdaterGetDoubleAttributeTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.tools.pulse.internal.data;
+
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.geode.test.junit.categories.UnitTest;
+import org.assertj.core.data.Offset;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(UnitTest.class)
+public class JMXDataUpdaterGetDoubleAttributeTest {
+
+  private Cluster cluster;
+  private JMXDataUpdater jmxDataUpdater;
+  private Float floatStat;
+  private Double doubleStat;
+
+  @Before
+  public void setUp() {
+    this.cluster = mock(Cluster.class);
+    this.jmxDataUpdater = new JMXDataUpdater("server", "cluster", this.cluster);
+    this.floatStat = 1.2345f;
+    this.doubleStat = 1.2345d;
+  }
+
+  @Test
+  public void shouldNotReturnZeroForFloat() {
+    double value = jmxDataUpdater.getDoubleAttribute(floatStat, "someStatistic");
+    assertThat(value).isNotEqualTo(0);
+  }
+
+  @Test
+  public void shouldNotReturnZeroForPrimitiveFloat() {
+    double value = jmxDataUpdater.getDoubleAttribute(floatStat.floatValue(), "someStatistic");
+    assertThat(value).isNotEqualTo(0);
+  }
+
+  @Test
+  public void returnsDoubleCloseToFloat() {
+    double value = jmxDataUpdater.getDoubleAttribute(floatStat, "someStatistic");
+    assertThat(value).isEqualTo(floatStat, Offset.offset(0.001d));
+  }
+
+  @Test
+  public void returnsDoubleCloseToPrimitiveFloat() {
+    double value = jmxDataUpdater.getDoubleAttribute(floatStat.floatValue(), "someStatistic");
+    assertThat(value).isEqualTo(floatStat, Offset.offset(0.001d));
+  }
+
+  @Test
+  public void returnsDoubleCloseToNegativeFloat() {
+    this.floatStat = -floatStat;
+    double value = jmxDataUpdater.getDoubleAttribute(floatStat, "someStatistic");
+    assertThat(value).isEqualTo(floatStat, Offset.offset(0.001d));
+  }
+
+  @Test
+  public void returnsDoubleForDouble() {
+    double value = jmxDataUpdater.getDoubleAttribute(doubleStat, "someStatistic");
+    assertThat(value).isEqualTo(floatStat, Offset.offset(0.001d));
+  }
+
+  @Test
+  public void returnsDoubleForDoublePrimitive() {
+    double value = jmxDataUpdater.getDoubleAttribute(doubleStat.doubleValue(), "someStatistic");
+    assertThat(value).isEqualTo(floatStat, Offset.offset(0.001d));
+  }
+
+  @Test
+  public void returnsZeroForNull() {
+    double value = jmxDataUpdater.getDoubleAttribute(null, "someStatistic");
+    assertThat(value).isEqualTo(0d, Offset.offset(0.001d));
+  }
+
+  @Test
+  public void returnsZeroForString() {
+    double value = jmxDataUpdater.getDoubleAttribute("abc", "someStatistic");
+    assertThat(value).isEqualTo(0d, Offset.offset(0.001d));
+  }
+
+}


### PR DESCRIPTION
 - Added tests for JMXDataUpdater::getDoubleAttribute()
 - JMXDataUpdater::getDoubleAttribute() now returns double approximations for floats rather than logging an error and returning zero.