### PR TITLE
GEODE-2092: Security examples should not be in the product code

### DIFF
--- a/geode-assembly/src/test/java/org/apache/geode/rest/internal/web/RestSecurityIntegrationTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/rest/internal/web/RestSecurityIntegrationTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.internal.AvailablePortHelper;
-import org.apache.geode.security.templates.SampleSecurityManager;
+import org.apache.geode.security.TestSecurityManager;
 import org.apache.geode.test.dunit.rules.ServerStarterRule;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.test.junit.categories.SecurityTest;
@@ -48,9 +48,9 @@ public class RestSecurityIntegrationTest {
   private static int restPort = AvailablePortHelper.getRandomAvailableTCPPort();
   static Properties properties = new Properties() {
     {
-      setProperty(SampleSecurityManager.SECURITY_JSON,
+      setProperty(TestSecurityManager.SECURITY_JSON,
           "org/apache/geode/management/internal/security/clientServer.json");
-      setProperty(SECURITY_MANAGER, SampleSecurityManager.class.getName());
+      setProperty(SECURITY_MANAGER, TestSecurityManager.class.getName());
       setProperty(START_DEV_REST_API, "true");
       setProperty(HTTP_SERVICE_BIND_ADDRESS, "localhost");
       setProperty(HTTP_SERVICE_PORT, restPort + "");

--- a/geode-assembly/src/test/java/org/apache/geode/rest/internal/web/RestSecurityPostProcessorTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/rest/internal/web/RestSecurityPostProcessorTest.java
@@ -31,7 +31,7 @@ import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.rest.internal.web.controllers.Customer;
 import org.apache.geode.rest.internal.web.controllers.RedactingPostProcessor;
-import org.apache.geode.security.templates.SampleSecurityManager;
+import org.apache.geode.security.TestSecurityManager;
 import org.apache.geode.test.dunit.rules.ServerStarterRule;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.test.junit.categories.SecurityTest;
@@ -54,9 +54,9 @@ public class RestSecurityPostProcessorTest {
   static int restPort = AvailablePortHelper.getRandomAvailableTCPPort();
   static Properties properties = new Properties() {
     {
-      setProperty(SampleSecurityManager.SECURITY_JSON,
+      setProperty(TestSecurityManager.SECURITY_JSON,
           "org/apache/geode/management/internal/security/clientServer.json");
-      setProperty(SECURITY_MANAGER, SampleSecurityManager.class.getName());
+      setProperty(SECURITY_MANAGER, TestSecurityManager.class.getName());
       setProperty(START_DEV_REST_API, "true");
       setProperty(HTTP_SERVICE_BIND_ADDRESS, "localhost");
       setProperty(HTTP_SERVICE_PORT, restPort + "");

--- a/geode-assembly/src/test/java/org/apache/geode/rest/internal/web/RestSecurityWithSSLTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/rest/internal/web/RestSecurityWithSSLTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
-import org.apache.geode.security.templates.SimpleSecurityManager;
+import org.apache.geode.security.SimpleTestSecurityManager;
 import org.apache.geode.test.dunit.rules.ServerStarterRule;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.test.junit.categories.SecurityTest;
@@ -54,7 +54,7 @@ public class RestSecurityWithSSLTest {
         RestSecurityWithSSLTest.class.getClassLoader().getResource("ssl/trusted.keystore");
 
     Properties properties = new Properties();
-    properties.setProperty(SECURITY_MANAGER, SimpleSecurityManager.class.getName());
+    properties.setProperty(SECURITY_MANAGER, SimpleTestSecurityManager.class.getName());
     properties.setProperty(START_DEV_REST_API, "true");
     properties.setProperty(HTTP_SERVICE_BIND_ADDRESS, "localhost");
     properties.setProperty(HTTP_SERVICE_PORT, restPort + "");

--- a/geode-assembly/src/test/java/org/apache/geode/rest/internal/web/SwaggerVerificationTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/rest/internal/web/SwaggerVerificationTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertThat;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.i18n.LocalizedStrings;
 import org.apache.geode.test.dunit.rules.ServerStarterRule;
-import org.apache.geode.security.templates.SimpleSecurityManager;
+import org.apache.geode.security.SimpleTestSecurityManager;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.test.junit.categories.RestAPITest;
 import org.apache.http.HttpResponse;
@@ -43,7 +43,7 @@ public class SwaggerVerificationTest {
   static Properties properties = new Properties() {
     {
       setProperty(START_DEV_REST_API, "true");
-      setProperty(SECURITY_MANAGER, SimpleSecurityManager.class.getName());
+      setProperty(SECURITY_MANAGER, SimpleTestSecurityManager.class.getName());
       setProperty(HTTP_SERVICE_BIND_ADDRESS, "localhost");
       setProperty(HTTP_SERVICE_PORT, restPort + "");
     }

--- a/geode-core/src/main/java/org/apache/geode/examples/security/ExamplePostProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/examples/security/ExamplePostProcessor.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.examples.security;
+
+import org.apache.geode.security.PostProcessor;
+
+import java.security.Principal;
+import java.util.Properties;
+
+/**
+ * This is example that implements PostProcessor
+ */
+public class ExamplePostProcessor implements PostProcessor {
+
+  @Override
+  public void init(final Properties securityProps) {}
+
+  /**
+   * This simply modifies the value with all the parameter values
+   *
+   * @param principal The principal that's accessing the value
+   * @param regionName The region that's been accessed. This could be null.
+   * @param key the key of the value that's been accessed. This could be null.
+   * @param value the value, this could be null.
+   * @return the processed value
+   */
+  @Override
+  public Object processRegionValue(Object principal, String regionName, Object key, Object value) {
+    String name = null;
+    if (principal instanceof Principal) {
+      name = ((Principal) principal).getName();
+    } else {
+      name = principal.toString();
+    }
+    return name + "/" + regionName + "/" + key + "/" + value;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/examples/security/ExampleSecurityManager.java
+++ b/geode-core/src/main/java/org/apache/geode/examples/security/ExampleSecurityManager.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.examples.security;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.IOUtils;
+import org.apache.geode.management.internal.security.ResourceConstants;
+import org.apache.geode.security.AuthenticationFailedException;
+import org.apache.geode.security.NotAuthorizedException;
+import org.apache.geode.security.ResourcePermission;
+import org.apache.geode.security.SecurityManager;
+import org.apache.shiro.authz.Permission;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * This class provides a sample implementation of {@link SecurityManager} for authentication and
+ * authorization initialized from data provided as JSON.
+ *
+ * <p>
+ * A Geode member must be configured with the following:
+ *
+ * <p>
+ * {@code security-manager = org.apache.geode.security.examples.SampleSecurityManager}
+ *
+ * <p>
+ * The class can be initialized with from a JSON resource called {@code security.json}. This file
+ * must exist on the classpath, so members should be started with an appropriate {@code --classpath}
+ * option.
+ *
+ * <p>
+ * The format of the JSON for configuration is as follows:
+ * 
+ * <pre>
+ * <code>
+ * {
+ *   "roles": [
+ *     {
+ *       "name": "admin",
+ *       "operationsAllowed": [
+ *         "CLUSTER:MANAGE",
+ *         "DATA:MANAGE"
+ *       ]
+ *     },
+ *     {
+ *       "name": "readRegionA",
+ *       "operationsAllowed": [
+ *         "DATA:READ"
+ *       ],
+ *       "regions": ["RegionA", "RegionB"]
+ *     }
+ *   ],
+ *   "users": [
+ *     {
+ *       "name": "admin",
+ *       "password": "secret",
+ *       "roles": ["admin"]
+ *     },
+ *     {
+ *       "name": "guest",
+ *       "password": "guest",
+ *       "roles": ["readRegionA"]
+ *     }
+ *   ]
+ * }
+ * </code>
+ * </pre>
+ */
+public class ExampleSecurityManager implements SecurityManager {
+
+  public static final String SECURITY_JSON = "security-json";
+
+  protected static final String DEFAULT_JSON_FILE_NAME = "security.json";
+
+  private Map<String, User> userNameToUser;
+
+  @Override
+  public boolean authorize(final Object principal, final ResourcePermission context) {
+    if (principal == null)
+      return false;
+
+    User user = this.userNameToUser.get(principal.toString());
+    if (user == null)
+      return false; // this user is not authorized to do anything
+
+    // check if the user has this permission defined in the context
+    for (Role role : this.userNameToUser.get(user.name).roles) {
+      for (Permission permitted : role.permissions) {
+        if (permitted.implies(context)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  @Override
+  public void init(final Properties securityProperties) throws NotAuthorizedException {
+    String jsonPropertyValue =
+        securityProperties != null ? securityProperties.getProperty(SECURITY_JSON) : null;
+    if (jsonPropertyValue == null) {
+      jsonPropertyValue = DEFAULT_JSON_FILE_NAME;
+    }
+
+    if (!initializeFromJsonResource(jsonPropertyValue)) {
+      throw new AuthenticationFailedException(
+          "SampleSecurityManager: unable to find json resource \"" + jsonPropertyValue
+              + "\" as specified by [" + SECURITY_JSON + "].");
+    }
+  }
+
+  @Override
+  public Object authenticate(final Properties credentials) throws AuthenticationFailedException {
+    String user = credentials.getProperty(ResourceConstants.USER_NAME);
+    String password = credentials.getProperty(ResourceConstants.PASSWORD);
+
+    User userObj = this.userNameToUser.get(user);
+    if (userObj == null) {
+      throw new AuthenticationFailedException("SampleSecurityManager: wrong username/password");
+    }
+
+    if (user != null && !userObj.password.equals(password) && !"".equals(user)) {
+      throw new AuthenticationFailedException("SampleSecurityManager: wrong username/password");
+    }
+
+    return user;
+  }
+
+  boolean initializeFromJson(final String json) {
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      JsonNode jsonNode = mapper.readTree(json);
+      this.userNameToUser = new HashMap<>();
+      Map<String, Role> roleMap = readRoles(jsonNode);
+      readUsers(this.userNameToUser, jsonNode, roleMap);
+      return true;
+    } catch (IOException ex) {
+      return false;
+    }
+  }
+
+  boolean initializeFromJsonResource(final String jsonResource) {
+    try {
+      InputStream input = ClassLoader.getSystemResourceAsStream(jsonResource);
+      if (input != null) {
+        initializeFromJson(readJsonFromInputStream(input));
+        return true;
+      }
+    } catch (IOException ex) {
+    }
+    return false;
+  }
+
+  User getUser(final String user) {
+    return this.userNameToUser.get(user);
+  }
+
+  private String readJsonFromInputStream(final InputStream input) throws IOException {
+    StringWriter writer = new StringWriter();
+    IOUtils.copy(input, writer, "UTF-8");
+    return writer.toString();
+  }
+
+  private void readUsers(final Map<String, User> rolesToUsers, final JsonNode node,
+      final Map<String, Role> roleMap) {
+    for (JsonNode usersNode : node.get("users")) {
+      User user = new User();
+      user.name = usersNode.get("name").asText();
+
+      if (usersNode.has("password")) {
+        user.password = usersNode.get("password").asText();
+      } else {
+        user.password = user.name;
+      }
+
+      for (JsonNode rolesNode : usersNode.get("roles")) {
+        user.roles.add(roleMap.get(rolesNode.asText()));
+      }
+
+      rolesToUsers.put(user.name, user);
+    }
+  }
+
+  private Map<String, Role> readRoles(final JsonNode jsonNode) {
+    if (jsonNode.get("roles") == null) {
+      return Collections.EMPTY_MAP;
+    }
+    Map<String, Role> roleMap = new HashMap<>();
+    for (JsonNode rolesNode : jsonNode.get("roles")) {
+      Role role = new Role();
+      role.name = rolesNode.get("name").asText();
+      String regionNames = null;
+      String keys = null;
+
+      JsonNode regionsNode = rolesNode.get("regions");
+      if (regionsNode != null) {
+        if (regionsNode.isArray()) {
+          regionNames = StreamSupport.stream(regionsNode.spliterator(), false).map(JsonNode::asText)
+              .collect(Collectors.joining(","));
+        } else {
+          regionNames = regionsNode.asText();
+        }
+      }
+
+      for (JsonNode operationsAllowedNode : rolesNode.get("operationsAllowed")) {
+        String[] parts = operationsAllowedNode.asText().split(":");
+        String resourcePart = (parts.length > 0) ? parts[0] : null;
+        String operationPart = (parts.length > 1) ? parts[1] : null;
+
+        if (parts.length > 2) {
+          regionNames = parts[2];
+        }
+        if (parts.length > 3) {
+          keys = parts[3];
+        }
+
+        String regionPart = (regionNames != null) ? regionNames : "*";
+        String keyPart = (keys != null) ? keys : "*";
+
+        role.permissions
+            .add(new ResourcePermission(resourcePart, operationPart, regionPart, keyPart));
+      }
+
+      roleMap.put(role.name, role);
+
+      if (rolesNode.has("serverGroup")) {
+        role.serverGroup = rolesNode.get("serverGroup").asText();
+      }
+    }
+
+    return roleMap;
+  }
+
+  static class Role {
+    List<ResourcePermission> permissions = new ArrayList<>();
+    String name;
+    String serverGroup;
+  }
+
+  static class User {
+    String name;
+    Set<Role> roles = new HashSet<>();
+    String password;
+  }
+
+}

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionConfigJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionConfigJUnitTest.java
@@ -31,8 +31,8 @@ import java.util.Properties;
 import org.apache.geode.InternalGemFireException;
 import org.apache.geode.UnmodifiableException;
 import org.apache.geode.internal.ConfigSource;
-import org.apache.geode.security.templates.SamplePostProcessor;
-import org.apache.geode.security.templates.SampleSecurityManager;
+import org.apache.geode.security.TestPostProcessor;
+import org.apache.geode.security.TestSecurityManager;
 import org.apache.geode.test.junit.categories.MembershipTest;
 import org.apache.geode.test.junit.categories.UnitTest;
 import org.junit.Before;
@@ -334,8 +334,8 @@ public class DistributionConfigJUnitTest {
   @Test
   public void testSecurityProps() {
     Properties props = new Properties();
-    props.put(SECURITY_MANAGER, SampleSecurityManager.class.getName());
-    props.put(SECURITY_POST_PROCESSOR, SamplePostProcessor.class.getName());
+    props.put(SECURITY_MANAGER, TestSecurityManager.class.getName());
+    props.put(SECURITY_POST_PROCESSOR, TestPostProcessor.class.getName());
     props.put(SECURITY_LOG_LEVEL, "config");
     // add another non-security property to verify it won't get put in the security properties
     props.put(ACK_WAIT_THRESHOLD, 2);
@@ -348,8 +348,8 @@ public class DistributionConfigJUnitTest {
   @Test
   public void testSecurityPropsWithNoSetter() {
     Properties props = new Properties();
-    props.put(SECURITY_MANAGER, SampleSecurityManager.class.getName());
-    props.put(SECURITY_POST_PROCESSOR, SamplePostProcessor.class.getName());
+    props.put(SECURITY_MANAGER, TestSecurityManager.class.getName());
+    props.put(SECURITY_POST_PROCESSOR, TestPostProcessor.class.getName());
     props.put(SECURITY_LOG_LEVEL, "config");
     // add another non-security property to verify it won't get put in the security properties
     props.put(ACK_WAIT_THRESHOLD, 2);

--- a/geode-core/src/test/java/org/apache/geode/internal/security/IntegratedSecurityServiceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/security/IntegratedSecurityServiceTest.java
@@ -24,9 +24,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.geode.security.GemFireSecurityException;
-import org.apache.geode.security.templates.SamplePostProcessor;
-import org.apache.geode.security.templates.SampleSecurityManager;
-import org.apache.geode.security.templates.SimpleSecurityManager;
+import org.apache.geode.security.TestPostProcessor;
+import org.apache.geode.security.TestSecurityManager;
+import org.apache.geode.security.SimpleTestSecurityManager;
 import org.apache.geode.test.junit.categories.UnitTest;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.mgt.DefaultSecurityManager;
@@ -104,9 +104,8 @@ public class IntegratedSecurityServiceTest {
 
   @Test
   public void testInitWithSecurityManager() {
-    properties.setProperty(SECURITY_MANAGER,
-        "org.apache.geode.security.templates.SampleSecurityManager");
-    properties.setProperty(SampleSecurityManager.SECURITY_JSON,
+    properties.setProperty(SECURITY_MANAGER, "org.apache.geode.security.TestSecurityManager");
+    properties.setProperty(TestSecurityManager.SECURITY_JSON,
         "org/apache/geode/security/templates/security.json");
 
     securityService.initSecurity(properties);
@@ -185,14 +184,14 @@ public class IntegratedSecurityServiceTest {
     assertFalse(securityService.isPeerSecurityRequired());
 
     // set a security manager
-    securityService.setSecurityManager(new SimpleSecurityManager());
+    securityService.setSecurityManager(new SimpleTestSecurityManager());
     assertTrue(securityService.isIntegratedSecurity());
     assertTrue(securityService.isClientSecurityRequired());
     assertTrue(securityService.isPeerSecurityRequired());
     assertFalse(securityService.needPostProcess());
 
     // set a post processor
-    securityService.setPostProcessor(new SamplePostProcessor());
+    securityService.setPostProcessor(new TestPostProcessor());
     assertTrue(securityService.isIntegratedSecurity());
     assertTrue(securityService.needPostProcess());
   }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CliCommandTestBase.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CliCommandTestBase.java
@@ -27,7 +27,7 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.geode.security.templates.SampleSecurityManager;
+import org.apache.geode.security.TestSecurityManager;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 
@@ -136,7 +136,7 @@ public abstract class CliCommandTestBase extends JUnit4CacheTestCase {
       }
 
       if (jsonFile != null) {
-        localProps.setProperty(SampleSecurityManager.SECURITY_JSON, jsonFile);
+        localProps.setProperty(TestSecurityManager.SECURITY_JSON, jsonFile);
       }
 
       final int[] ports = AvailablePortHelper.getRandomAvailableTCPPorts(2);

--- a/geode-core/src/test/java/org/apache/geode/management/internal/security/CacheServerStartupRule.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/security/CacheServerStartupRule.java
@@ -25,7 +25,7 @@ import org.junit.Before;
 import org.junit.rules.ExternalResource;
 
 import org.apache.geode.cache.Cache;
-import org.apache.geode.security.templates.SampleSecurityManager;
+import org.apache.geode.security.TestSecurityManager;
 import org.apache.geode.test.dunit.rules.ServerStarterRule;
 
 /**
@@ -46,8 +46,8 @@ public class CacheServerStartupRule extends ExternalResource implements Serializ
       properties.put(JMX_MANAGER_PORT, String.valueOf(jmxManagerPort));
     }
     if (jsonFile != null) {
-      properties.put(SECURITY_MANAGER, SampleSecurityManager.class.getName());
-      properties.put(SampleSecurityManager.SECURITY_JSON, jsonFile);
+      properties.put(SECURITY_MANAGER, TestSecurityManager.class.getName());
+      properties.put(TestSecurityManager.SECURITY_JSON, jsonFile);
     }
     serverStarter = new ServerStarterRule(properties);
   }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/security/GfshCommandsPostProcessorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/security/GfshCommandsPostProcessorTest.java
@@ -22,8 +22,8 @@ import static org.apache.geode.internal.Assert.assertTrue;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.management.internal.cli.HeadlessGfsh;
-import org.apache.geode.security.templates.SamplePostProcessor;
-import org.apache.geode.security.templates.SampleSecurityManager;
+import org.apache.geode.security.TestPostProcessor;
+import org.apache.geode.security.TestSecurityManager;
 import org.apache.geode.test.dunit.rules.ConnectionConfiguration;
 import org.apache.geode.test.dunit.rules.GfshShellConnectionRule;
 import org.apache.geode.test.dunit.rules.ServerStarterRule;
@@ -44,8 +44,8 @@ public class GfshCommandsPostProcessorTest {
   static Properties properties = new Properties() {
     {
       setProperty(JMX_MANAGER_PORT, jmxPort + "");
-      setProperty(SECURITY_POST_PROCESSOR, SamplePostProcessor.class.getName());
-      setProperty(SECURITY_MANAGER, SampleSecurityManager.class.getName());
+      setProperty(SECURITY_POST_PROCESSOR, TestPostProcessor.class.getName());
+      setProperty(SECURITY_MANAGER, TestSecurityManager.class.getName());
       setProperty("security-json",
           "org/apache/geode/management/internal/security/cacheServer.json");
     }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/security/GfshCommandsSecurityTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/security/GfshCommandsSecurityTest.java
@@ -31,7 +31,7 @@ import org.apache.geode.management.internal.cli.HeadlessGfsh;
 import org.apache.geode.management.internal.cli.result.CommandResult;
 import org.apache.geode.management.internal.cli.result.ErrorResultData;
 import org.apache.geode.management.internal.cli.result.ResultBuilder;
-import org.apache.geode.security.templates.SampleSecurityManager;
+import org.apache.geode.security.TestSecurityManager;
 import org.apache.geode.test.dunit.rules.ConnectionConfiguration;
 import org.apache.geode.test.dunit.rules.GfshShellConnectionRule;
 import org.apache.geode.test.dunit.rules.ServerStarterRule;
@@ -69,7 +69,7 @@ public class GfshCommandsSecurityTest {
     {
       setProperty(JMX_MANAGER_PORT, jmxPort + "");
       setProperty(HTTP_SERVICE_PORT, httpPort + "");
-      setProperty(SECURITY_MANAGER, SampleSecurityManager.class.getName());
+      setProperty(SECURITY_MANAGER, TestSecurityManager.class.getName());
       setProperty("security-json",
           "org/apache/geode/management/internal/security/cacheServer.json");
     }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/security/IntegratedSecurityServiceCustomRealmJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/security/IntegratedSecurityServiceCustomRealmJUnitTest.java
@@ -16,7 +16,7 @@ package org.apache.geode.management.internal.security;
 
 import static org.apache.geode.distributed.ConfigurationProperties.*;
 
-import org.apache.geode.security.templates.SampleSecurityManager;
+import org.apache.geode.security.TestSecurityManager;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
@@ -35,9 +35,9 @@ public class IntegratedSecurityServiceCustomRealmJUnitTest
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    props.put(SampleSecurityManager.SECURITY_JSON,
+    props.put(TestSecurityManager.SECURITY_JSON,
         "org/apache/geode/management/internal/security/shiro-ini.json");
-    props.put(SECURITY_MANAGER, SampleSecurityManager.class.getName());
+    props.put(SECURITY_MANAGER, TestSecurityManager.class.getName());
     IntegratedSecurityService.getSecurityService().initSecurity(props);
   }
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/security/MultiUserDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/security/MultiUserDUnitTest.java
@@ -23,7 +23,7 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import com.jayway.awaitility.Awaitility;
-import org.apache.geode.security.templates.SampleSecurityManager;
+import org.apache.geode.security.TestSecurityManager;
 import org.json.JSONException;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -51,7 +51,7 @@ public class MultiUserDUnitTest extends CliCommandTestBase {
   public void testMultiUser() throws IOException, JSONException, InterruptedException {
     Properties properties = new Properties();
     properties.put(NAME, MultiUserDUnitTest.class.getSimpleName());
-    properties.put(SECURITY_MANAGER, SampleSecurityManager.class.getName());
+    properties.put(SECURITY_MANAGER, TestSecurityManager.class.getName());
 
     // set up vm_0 the secure jmx manager
     Object[] results = setUpJMXManagerOnVM(0, properties,

--- a/geode-core/src/test/java/org/apache/geode/security/AbstractSecureServerDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/AbstractSecureServerDUnitTest.java
@@ -27,7 +27,6 @@ import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.client.ClientCache;
 import org.apache.geode.cache.client.ClientCacheFactory;
 import org.apache.geode.cache.client.ClientRegionShortcut;
-import org.apache.geode.security.templates.SampleSecurityManager;
 import org.apache.geode.security.templates.UserPasswordAuthInit;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.IgnoredException;
@@ -56,8 +55,8 @@ public abstract class AbstractSecureServerDUnitTest extends JUnit4DistributedTes
   public Properties getProperties() {
     return new Properties() {
       {
-        setProperty(SECURITY_MANAGER, SampleSecurityManager.class.getName());
-        setProperty(SampleSecurityManager.SECURITY_JSON,
+        setProperty(SECURITY_MANAGER, TestSecurityManager.class.getName());
+        setProperty(TestSecurityManager.SECURITY_JSON,
             "org/apache/geode/management/internal/security/clientServer.json");
       }
     };

--- a/geode-core/src/test/java/org/apache/geode/security/CacheFactoryWithSecurityObjectTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/CacheFactoryWithSecurityObjectTest.java
@@ -24,8 +24,6 @@ import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.security.templates.DummyAuthenticator;
-import org.apache.geode.security.templates.SamplePostProcessor;
-import org.apache.geode.security.templates.SimpleSecurityManager;
 import org.apache.geode.test.junit.categories.IntegrationTest;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.junit.After;
@@ -46,7 +44,7 @@ public class CacheFactoryWithSecurityObjectTest {
   @Before
   public void before() throws Exception {
     securityService = SecurityService.getSecurityService();
-    simpleSecurityManager = new SimpleSecurityManager();
+    simpleSecurityManager = new SimpleTestSecurityManager();
     properties.setProperty("mcast-port", "0");
   }
 
@@ -61,7 +59,7 @@ public class CacheFactoryWithSecurityObjectTest {
 
   @Test
   public void testCreateCacheWithPostProcessor() throws Exception {
-    cache = new CacheFactory(properties).setPostProcessor(new SamplePostProcessor())
+    cache = new CacheFactory(properties).setPostProcessor(new TestPostProcessor())
         .setSecurityManager(null).create();
     assertFalse(securityService.isIntegratedSecurity());
     assertFalse(securityService.needPostProcess());
@@ -74,7 +72,7 @@ public class CacheFactoryWithSecurityObjectTest {
         DummyAuthenticator.class.getName());
 
     cache = new CacheFactory(properties).setSecurityManager(simpleSecurityManager)
-        .setPostProcessor(new SamplePostProcessor()).create();
+        .setPostProcessor(new TestPostProcessor()).create();
 
     assertTrue(securityService.isIntegratedSecurity());
     assertTrue(securityService.isClientSecurityRequired());

--- a/geode-core/src/test/java/org/apache/geode/security/ClusterConfigWithoutSecurityDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/ClusterConfigWithoutSecurityDUnitTest.java
@@ -31,7 +31,6 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.GemFireConfigException;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.internal.i18n.LocalizedStrings;
-import org.apache.geode.security.templates.SimpleSecurityManager;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.dunit.rules.LocatorServerStartupRule;
@@ -65,7 +64,7 @@ public class ClusterConfigWithoutSecurityDUnitTest extends JUnit4DistributedTest
   @Test
   public void serverShouldBeAllowedToStartWithSecurityIfNotUsingClusterConfig() throws Exception {
     Properties props = new Properties();
-    props.setProperty(SECURITY_MANAGER, SimpleSecurityManager.class.getName());
+    props.setProperty(SECURITY_MANAGER, SimpleTestSecurityManager.class.getName());
     props.setProperty(SECURITY_POST_PROCESSOR, PDXPostProcessor.class.getName());
 
     props.setProperty("use-cluster-configuration", "false");
@@ -78,7 +77,8 @@ public class ClusterConfigWithoutSecurityDUnitTest extends JUnit4DistributedTest
     // after cache is created, the configuration won't chagne
     Properties secProps = ds.getSecurityProperties();
     assertEquals(2, secProps.size());
-    assertEquals(SimpleSecurityManager.class.getName(), secProps.getProperty("security-manager"));
+    assertEquals(SimpleTestSecurityManager.class.getName(),
+        secProps.getProperty("security-manager"));
     assertEquals(PDXPostProcessor.class.getName(), secProps.getProperty("security-post-processor"));
   }
 

--- a/geode-core/src/test/java/org/apache/geode/security/IntegratedSecurityCacheLifecycleDistributedTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/IntegratedSecurityCacheLifecycleDistributedTest.java
@@ -25,7 +25,6 @@ import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.security.IntegratedSecurityService;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.management.ManagementService;
-import org.apache.geode.security.templates.SampleSecurityManager;
 import org.apache.geode.test.dunit.DistributedTestUtils;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.NetworkUtils;
@@ -63,7 +62,7 @@ public class IntegratedSecurityCacheLifecycleDistributedTest extends JUnit4Cache
       DistributedTestUtils.deleteLocatorStateFile(locatorPort);
 
       final Properties properties = new Properties();
-      properties.setProperty(SampleSecurityManager.SECURITY_JSON,
+      properties.setProperty(TestSecurityManager.SECURITY_JSON,
           "org/apache/geode/management/internal/security/clientServer.json");
       properties.setProperty(LOCATORS, locators);
       properties.setProperty(MCAST_PORT, "0");
@@ -102,7 +101,7 @@ public class IntegratedSecurityCacheLifecycleDistributedTest extends JUnit4Cache
 
   private void connect() throws IOException {
     final Properties properties = new Properties();
-    properties.setProperty(SampleSecurityManager.SECURITY_JSON,
+    properties.setProperty(TestSecurityManager.SECURITY_JSON,
         "org/apache/geode/management/internal/security/clientServer.json");
     properties.setProperty(LOCATORS, locators);
     properties.setProperty(MCAST_PORT, "0");

--- a/geode-core/src/test/java/org/apache/geode/security/IntegratedSecurityPeerAuthDistributedTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/IntegratedSecurityPeerAuthDistributedTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.internal.AvailablePort;
-import org.apache.geode.security.templates.SampleSecurityManager;
 import org.apache.geode.security.templates.UserPasswordAuthInit;
 import org.apache.geode.test.dunit.DistributedTestUtils;
 import org.apache.geode.test.dunit.Host;
@@ -61,7 +60,7 @@ public class IntegratedSecurityPeerAuthDistributedTest extends JUnit4CacheTestCa
       DistributedTestUtils.deleteLocatorStateFile(locatorPort);
 
       final Properties properties = createProperties(locators);
-      properties.setProperty(SampleSecurityManager.SECURITY_JSON,
+      properties.setProperty(TestSecurityManager.SECURITY_JSON,
           "org/apache/geode/security/peerAuth.json");
       properties.setProperty(UserPasswordAuthInit.USER_NAME, "locator1");
       properties.setProperty(UserPasswordAuthInit.PASSWORD, "1234567");
@@ -75,7 +74,7 @@ public class IntegratedSecurityPeerAuthDistributedTest extends JUnit4CacheTestCa
       spySecurityManager = new SpySecurityManager();
 
       final Properties properties = createProperties(locators);
-      properties.setProperty(SampleSecurityManager.SECURITY_JSON,
+      properties.setProperty(TestSecurityManager.SECURITY_JSON,
           "org/apache/geode/security/peerAuth.json");
       properties.setProperty(UserPasswordAuthInit.USER_NAME, "server1");
       properties.setProperty(UserPasswordAuthInit.PASSWORD, "1234567");
@@ -88,7 +87,7 @@ public class IntegratedSecurityPeerAuthDistributedTest extends JUnit4CacheTestCa
       spySecurityManager = new SpySecurityManager();
 
       final Properties properties = createProperties(locators);
-      properties.setProperty(SampleSecurityManager.SECURITY_JSON,
+      properties.setProperty(TestSecurityManager.SECURITY_JSON,
           "org/apache/geode/security/peerAuth.json");
       properties.setProperty(UserPasswordAuthInit.USER_NAME, "server2");
       properties.setProperty(UserPasswordAuthInit.PASSWORD, "1234567");
@@ -103,7 +102,7 @@ public class IntegratedSecurityPeerAuthDistributedTest extends JUnit4CacheTestCa
     spySecurityManager = new SpySecurityManager();
 
     final Properties properties = createProperties(locators);
-    properties.setProperty(SampleSecurityManager.SECURITY_JSON,
+    properties.setProperty(TestSecurityManager.SECURITY_JSON,
         "org/apache/geode/security/peerAuth.json");
     properties.setProperty(UserPasswordAuthInit.USER_NAME, "stranger");
     properties.setProperty(UserPasswordAuthInit.PASSWORD, "1234567");
@@ -132,7 +131,7 @@ public class IntegratedSecurityPeerAuthDistributedTest extends JUnit4CacheTestCa
     return allProperties;
   }
 
-  public static class SpySecurityManager extends SampleSecurityManager {
+  public static class SpySecurityManager extends TestSecurityManager {
 
     static int initInvoked = 0;
     static int closeInvoked = 0;

--- a/geode-core/src/test/java/org/apache/geode/security/PDXGfshPostProcessorOnRemoteServerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/PDXGfshPostProcessorOnRemoteServerTest.java
@@ -44,7 +44,6 @@ import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.result.CommandResult;
 import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
 import org.apache.geode.pdx.SimpleClass;
-import org.apache.geode.security.templates.SampleSecurityManager;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
@@ -72,9 +71,9 @@ public class PDXGfshPostProcessorOnRemoteServerTest extends JUnit4DistributedTes
     int jmxPort = ports[1];
     locator.invoke(() -> {
       Properties props = new Properties();
-      props.setProperty(SampleSecurityManager.SECURITY_JSON,
+      props.setProperty(TestSecurityManager.SECURITY_JSON,
           "org/apache/geode/management/internal/security/clientServer.json");
-      props.setProperty(SECURITY_MANAGER, SampleSecurityManager.class.getName());
+      props.setProperty(SECURITY_MANAGER, TestSecurityManager.class.getName());
       props.setProperty(MCAST_PORT, "0");
       props.put(JMX_MANAGER, "true");
       props.put(JMX_MANAGER_START, "true");
@@ -89,9 +88,9 @@ public class PDXGfshPostProcessorOnRemoteServerTest extends JUnit4DistributedTes
       Properties props = new Properties();
       props.setProperty(MCAST_PORT, "0");
       props.setProperty(LOCATORS, locators);
-      props.setProperty(SampleSecurityManager.SECURITY_JSON,
+      props.setProperty(TestSecurityManager.SECURITY_JSON,
           "org/apache/geode/management/internal/security/clientServer.json");
-      props.setProperty(SECURITY_MANAGER, SampleSecurityManager.class.getName());
+      props.setProperty(SECURITY_MANAGER, TestSecurityManager.class.getName());
       props.setProperty(SECURITY_POST_PROCESSOR, PDXPostProcessor.class.getName());
       props.setProperty(USE_CLUSTER_CONFIGURATION, "true");
 

--- a/geode-core/src/test/java/org/apache/geode/security/PeerSecurityWithEmbeddedLocatorDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/PeerSecurityWithEmbeddedLocatorDUnitTest.java
@@ -26,7 +26,6 @@ import org.junit.experimental.categories.Category;
 
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.security.templates.DummyAuthenticator;
-import org.apache.geode.security.templates.SimpleSecurityManager;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.dunit.rules.LocatorServerStartupRule;
@@ -46,7 +45,7 @@ public class PeerSecurityWithEmbeddedLocatorDUnitTest extends JUnit4DistributedT
     int locatorPort = AvailablePortHelper.getRandomAvailableTCPPort();
 
     Properties server0Props = new Properties();
-    server0Props.setProperty(SECURITY_MANAGER, SimpleSecurityManager.class.getName());
+    server0Props.setProperty(SECURITY_MANAGER, SimpleTestSecurityManager.class.getName());
     server0Props.setProperty("start-locator", "localhost[" + locatorPort + "]");
     lsRule.getServerVM(0, server0Props);
 

--- a/geode-core/src/test/java/org/apache/geode/security/PostProcessorDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/PostProcessorDUnitTest.java
@@ -35,7 +35,6 @@ import org.apache.geode.cache.client.Pool;
 import org.apache.geode.cache.client.PoolManager;
 import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.util.CacheListenerAdapter;
-import org.apache.geode.security.templates.SamplePostProcessor;
 import org.apache.geode.test.junit.categories.DistributedTest;
 import org.apache.geode.test.junit.categories.SecurityTest;
 
@@ -44,7 +43,7 @@ public class PostProcessorDUnitTest extends AbstractSecureServerDUnitTest {
 
   public Properties getProperties() {
     Properties properties = super.getProperties();
-    properties.setProperty(SECURITY_POST_PROCESSOR, SamplePostProcessor.class.getName());
+    properties.setProperty(SECURITY_POST_PROCESSOR, TestPostProcessor.class.getName());
     return properties;
   }
 

--- a/geode-core/src/test/java/org/apache/geode/security/SampleSecurityManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/SampleSecurityManagerTest.java
@@ -12,32 +12,30 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.security.templates;
+package org.apache.geode.security;
 
-import static org.assertj.core.api.Assertions.*;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.util.Properties;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.geode.security.TestSecurityManager.User;
+import org.apache.geode.test.junit.categories.IntegrationTest;
+import org.apache.geode.test.junit.categories.SecurityTest;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
-import org.apache.geode.test.junit.categories.SecurityTest;
-import org.apache.geode.test.junit.categories.IntegrationTest;
-import org.apache.geode.security.templates.SampleSecurityManager.Role;
-import org.apache.geode.security.templates.SampleSecurityManager.User;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.util.Properties;
 
 @Category({IntegrationTest.class, SecurityTest.class})
 public class SampleSecurityManagerTest {
 
-  private SampleSecurityManager sampleSecurityManager;
+  private TestSecurityManager sampleSecurityManager;
   private String jsonResource;
   private File jsonFile;
   private String json;
@@ -59,7 +57,7 @@ public class SampleSecurityManagerTest {
 
     // string
     this.json = FileUtils.readFileToString(this.jsonFile, "UTF-8");
-    this.sampleSecurityManager = new SampleSecurityManager();
+    this.sampleSecurityManager = new TestSecurityManager();
   }
 
   @Test
@@ -83,7 +81,7 @@ public class SampleSecurityManagerTest {
   @Test
   public void initShouldUsePropertyAsJsonResource() throws Exception {
     Properties securityProperties = new Properties();
-    securityProperties.setProperty(SampleSecurityManager.SECURITY_JSON, this.jsonResource);
+    securityProperties.setProperty(TestSecurityManager.SECURITY_JSON, this.jsonResource);
     this.sampleSecurityManager.init(securityProperties);
     verifySecurityManagerState();
   }

--- a/geode-core/src/test/java/org/apache/geode/security/SecurityClusterConfigDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/SecurityClusterConfigDUnitTest.java
@@ -27,7 +27,6 @@ import static org.junit.Assert.assertTrue;
 import org.apache.geode.GemFireConfigException;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.internal.i18n.LocalizedStrings;
-import org.apache.geode.security.templates.SimpleSecurityManager;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.dunit.rules.LocatorServerStartupRule;
@@ -54,7 +53,7 @@ public class SecurityClusterConfigDUnitTest extends JUnit4DistributedTestCase {
     IgnoredException
         .addIgnoredException(LocalizedStrings.GEMFIRE_CACHE_SECURITY_MISCONFIGURATION_2.toString());
     Properties props = new Properties();
-    props.setProperty(SECURITY_MANAGER, SimpleSecurityManager.class.getName());
+    props.setProperty(SECURITY_MANAGER, SimpleTestSecurityManager.class.getName());
     props.setProperty(JMX_MANAGER, "false");
     props.setProperty(JMX_MANAGER_START, "false");
     props.setProperty(JMX_MANAGER_PORT, 0 + "");
@@ -90,7 +89,7 @@ public class SecurityClusterConfigDUnitTest extends JUnit4DistributedTestCase {
     props.setProperty("security-username", "cluster");
     props.setProperty("security-password", "cluster");
     props.setProperty("use-cluster-configuration", "true");
-    props.setProperty(SECURITY_MANAGER, SimpleSecurityManager.class.getName());
+    props.setProperty(SECURITY_MANAGER, SimpleTestSecurityManager.class.getName());
 
     // initial security properties should only contain initial set of values
     ServerStarterRule serverStarter = new ServerStarterRule(props);

--- a/geode-core/src/test/java/org/apache/geode/security/SecurityWithoutClusterConfigDUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/SecurityWithoutClusterConfigDUnitTest.java
@@ -27,8 +27,6 @@ import org.junit.experimental.categories.Category;
 
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.internal.i18n.LocalizedStrings;
-import org.apache.geode.security.templates.SampleSecurityManager;
-import org.apache.geode.security.templates.SimpleSecurityManager;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.dunit.rules.LocatorServerStartupRule;
@@ -50,7 +48,7 @@ public class SecurityWithoutClusterConfigDUnitTest extends JUnit4DistributedTest
     IgnoredException
         .addIgnoredException(LocalizedStrings.GEMFIRE_CACHE_SECURITY_MISCONFIGURATION_2.toString());
     Properties props = new Properties();
-    props.setProperty(SECURITY_MANAGER, SimpleSecurityManager.class.getName());
+    props.setProperty(SECURITY_MANAGER, SimpleTestSecurityManager.class.getName());
     props.setProperty(SECURITY_POST_PROCESSOR, PDXPostProcessor.class.getName());
     props.setProperty(ENABLE_CLUSTER_CONFIGURATION, "false");
     lsRule.getLocatorVM(0, props);
@@ -66,7 +64,7 @@ public class SecurityWithoutClusterConfigDUnitTest extends JUnit4DistributedTest
     // the following are needed for peer-to-peer authentication
     props.setProperty("security-username", "cluster");
     props.setProperty("security-password", "cluster");
-    props.setProperty("security-manager", SampleSecurityManager.class.getName());
+    props.setProperty("security-manager", TestSecurityManager.class.getName());
     props.setProperty("use-cluster-configuration", "true");
 
     // initial security properties should only contain initial set of values
@@ -78,7 +76,7 @@ public class SecurityWithoutClusterConfigDUnitTest extends JUnit4DistributedTest
     // after cache is created, we got the security props passed in by cluster config
     Properties secProps = ds.getSecurityProperties();
     assertEquals(3, secProps.size());
-    assertEquals(SampleSecurityManager.class.getName(), secProps.getProperty("security-manager"));
+    assertEquals(TestSecurityManager.class.getName(), secProps.getProperty("security-manager"));
     assertFalse(secProps.containsKey("security-post-processor"));
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/security/SimpleSecurityManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/SimpleSecurityManagerTest.java
@@ -13,7 +13,7 @@
  * the License.
  */
 
-package org.apache.geode.security.templates;
+package org.apache.geode.security;
 
 import static org.apache.geode.internal.Assert.assertTrue;
 import static org.assertj.core.api.Assertions.*;
@@ -21,6 +21,7 @@ import static org.junit.Assert.*;
 
 import java.util.Properties;
 
+import org.apache.geode.security.SimpleTestSecurityManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -32,12 +33,12 @@ import org.apache.geode.test.junit.categories.UnitTest;
 
 @Category({UnitTest.class, SecurityTest.class})
 public class SimpleSecurityManagerTest {
-  private SimpleSecurityManager manager;
+  private SimpleTestSecurityManager manager;
   private Properties credentials;
 
   @Before
   public void before() {
-    manager = new SimpleSecurityManager();
+    manager = new SimpleTestSecurityManager();
     credentials = new Properties();
   }
 

--- a/geode-core/src/test/java/org/apache/geode/security/SimpleTestSecurityManager.java
+++ b/geode-core/src/test/java/org/apache/geode/security/SimpleTestSecurityManager.java
@@ -13,13 +13,9 @@
  * the License.
  */
 
-package org.apache.geode.security.templates;
+package org.apache.geode.security;
 
 import java.util.Properties;
-
-import org.apache.geode.security.AuthenticationFailedException;
-import org.apache.geode.security.ResourcePermission;
-import org.apache.geode.security.SecurityManager;
 
 /**
  * This class provides a simple implementation of {@link SecurityManager} for authentication and
@@ -36,7 +32,7 @@ import org.apache.geode.security.SecurityManager;
  * data:write data:write:regionA username = cluster: authorized for all cluster operations username
  * = cluserRead: authorzed for all cluster read operations
  */
-public class SimpleSecurityManager implements SecurityManager {
+public class SimpleTestSecurityManager implements SecurityManager {
   @Override
   public void init(final Properties securityProps) {}
 

--- a/geode-core/src/test/java/org/apache/geode/security/StartServerAuthorizationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/security/StartServerAuthorizationTest.java
@@ -26,7 +26,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.security.templates.SimpleSecurityManager;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.dunit.rules.LocatorServerStartupRule;
@@ -42,7 +41,7 @@ public class StartServerAuthorizationTest extends JUnit4DistributedTestCase {
   @Before
   public void before() throws Exception {
     Properties props = new Properties();
-    props.setProperty(SECURITY_MANAGER, SimpleSecurityManager.class.getName());
+    props.setProperty(SECURITY_MANAGER, SimpleTestSecurityManager.class.getName());
     lsRule.getLocatorVM(0, props);
   }
 

--- a/geode-core/src/test/java/org/apache/geode/security/TestPostProcessor.java
+++ b/geode-core/src/test/java/org/apache/geode/security/TestPostProcessor.java
@@ -12,17 +12,15 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.security.templates;
+package org.apache.geode.security;
 
 import java.security.Principal;
 import java.util.Properties;
 
-import org.apache.geode.security.PostProcessor;
-
 /**
  * This is example that implements PostProcessor
  */
-public class SamplePostProcessor implements PostProcessor {
+public class TestPostProcessor implements PostProcessor {
 
   @Override
   public void init(final Properties securityProps) {}

--- a/geode-core/src/test/java/org/apache/geode/security/TestSecurityManager.java
+++ b/geode-core/src/test/java/org/apache/geode/security/TestSecurityManager.java
@@ -12,7 +12,13 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.security.templates;
+package org.apache.geode.security;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.IOUtils;
+import org.apache.geode.management.internal.security.ResourceConstants;
+import org.apache.shiro.authz.Permission;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,17 +33,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.io.IOUtils;
-import org.apache.geode.security.ResourcePermission;
-import org.apache.geode.security.SecurityManager;
-import org.apache.shiro.authz.Permission;
-
-import org.apache.geode.management.internal.security.ResourceConstants;
-import org.apache.geode.security.AuthenticationFailedException;
-import org.apache.geode.security.NotAuthorizedException;
 
 /**
  * This class provides a sample implementation of {@link SecurityManager} for authentication and
@@ -92,7 +87,7 @@ import org.apache.geode.security.NotAuthorizedException;
  * </code>
  * </pre>
  */
-public class SampleSecurityManager implements SecurityManager {
+public class TestSecurityManager implements SecurityManager {
 
   public static final String SECURITY_JSON = "security-json";
 
@@ -258,13 +253,13 @@ public class SampleSecurityManager implements SecurityManager {
     return roleMap;
   }
 
-  static class Role {
+  public static class Role {
     List<ResourcePermission> permissions = new ArrayList<>();
     String name;
     String serverGroup;
   }
 
-  static class User {
+  public static class User {
     String name;
     Set<Role> roles = new HashSet<>();
     String password;

--- a/geode-cq/src/test/java/org/apache/geode/security/CQClientAuthDunitTest.java
+++ b/geode-cq/src/test/java/org/apache/geode/security/CQClientAuthDunitTest.java
@@ -33,7 +33,6 @@ import org.apache.geode.cache.query.CqAttributes;
 import org.apache.geode.cache.query.CqAttributesFactory;
 import org.apache.geode.cache.query.CqQuery;
 import org.apache.geode.cache.query.QueryService;
-import org.apache.geode.security.templates.SamplePostProcessor;
 import org.apache.geode.security.templates.UserPasswordAuthInit;
 import org.apache.geode.test.junit.categories.DistributedTest;
 import org.apache.geode.test.junit.categories.SecurityTest;
@@ -43,7 +42,7 @@ public class CQClientAuthDunitTest extends AbstractSecureServerDUnitTest {
 
   public Properties getProperties() {
     Properties properties = super.getProperties();
-    properties.setProperty(SECURITY_POST_PROCESSOR, SamplePostProcessor.class.getName());
+    properties.setProperty(SECURITY_POST_PROCESSOR, TestPostProcessor.class.getName());
     return properties;
   }
 

--- a/geode-cq/src/test/java/org/apache/geode/security/CQPostProcessorDunitTest.java
+++ b/geode-cq/src/test/java/org/apache/geode/security/CQPostProcessorDunitTest.java
@@ -34,7 +34,6 @@ import org.apache.geode.cache.query.CqQuery;
 import org.apache.geode.cache.query.CqResults;
 import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.cache.query.internal.cq.CqListenerImpl;
-import org.apache.geode.security.templates.SamplePostProcessor;
 import org.apache.geode.test.junit.categories.DistributedTest;
 import org.apache.geode.test.junit.categories.SecurityTest;
 
@@ -43,7 +42,7 @@ public class CQPostProcessorDunitTest extends AbstractSecureServerDUnitTest {
 
   public Properties getProperties() {
     Properties properties = super.getProperties();
-    properties.setProperty(SECURITY_POST_PROCESSOR, SamplePostProcessor.class.getName());
+    properties.setProperty(SECURITY_POST_PROCESSOR, TestPostProcessor.class.getName());
     return properties;
   }
 

--- a/geode-pulse/src/test/java/org/apache/geode/tools/pulse/tests/Server.java
+++ b/geode-pulse/src/test/java/org/apache/geode/tools/pulse/tests/Server.java
@@ -37,7 +37,7 @@ import javax.management.remote.JMXConnectorServerFactory;
 import javax.management.remote.JMXServiceURL;
 
 import org.apache.geode.tools.pulse.internal.data.PulseConstants;
-import org.apache.geode.security.templates.SampleSecurityManager;
+import org.apache.geode.security.TestSecurityManager;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.mgt.DefaultSecurityManager;
 import org.apache.shiro.mgt.SecurityManager;
@@ -73,8 +73,8 @@ public class Server {
 
       // set up Shiro Security Manager
       Properties securityProperties = new Properties();
-      securityProperties.setProperty(SampleSecurityManager.SECURITY_JSON, jsonAuthFile);
-      Realm realm = new CustomAuthRealm(SampleSecurityManager.class.getName(), securityProperties);
+      securityProperties.setProperty(TestSecurityManager.SECURITY_JSON, jsonAuthFile);
+      Realm realm = new CustomAuthRealm(TestSecurityManager.class.getName(), securityProperties);
       SecurityManager securityManager = new DefaultSecurityManager(realm);
       SecurityUtils.setSecurityManager(securityManager);
 

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/misc/NewWanAuthenticationDUnitTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/misc/NewWanAuthenticationDUnitTest.java
@@ -21,7 +21,7 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import com.jayway.awaitility.Awaitility;
-import org.apache.geode.security.templates.SampleSecurityManager;
+import org.apache.geode.security.TestSecurityManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -304,7 +304,7 @@ public class NewWanAuthenticationDUnitTest extends WANTestBase {
 
   private static Properties buildSecurityProperties(String username, String password) {
     Properties props = new Properties();
-    props.put(SECURITY_MANAGER, SampleSecurityManager.class.getName());
+    props.put(SECURITY_MANAGER, TestSecurityManager.class.getName());
     props.put("security-json", "org/apache/geode/security/templates/security.json");
     props.put(SECURITY_CLIENT_AUTH_INIT, UserPasswdAI.class.getName());
     props.put("security-username", username);


### PR DESCRIPTION
Moved examples to geode-core/src/main/java/org/apache/geode/examples/security/
Copied old Sample/Simple code to test packages as many tests rely on these classes.
Deleted SimpleSecurityManager example class