### PR TITLE
Properly close WebDriver for UITests

### DIFF
--- a/geode-pulse/src/test/java/org/apache/geode/tools/pulse/tests/rules/ScreenshotOnFailureRule.java
+++ b/geode-pulse/src/test/java/org/apache/geode/tools/pulse/tests/rules/ScreenshotOnFailureRule.java
@@ -45,7 +45,9 @@ public class ScreenshotOnFailureRule extends TestWatcher {
     if (driver instanceof TakesScreenshot) {
       File tempFile = ((TakesScreenshot) driver).getScreenshotAs(OutputType.FILE);
       try {
-        FileUtils.copyFile(tempFile, new File("build/screenshots/" + screenshotName + ".png"));
+        File screenshot = new File("build/screenshots/" + screenshotName + ".png");
+        FileUtils.copyFile(tempFile, screenshot);
+        System.err.println("Screenshot saved to: " + screenshot.getCanonicalPath());
       } catch (IOException e) {
         throw new Error(e);
       }

--- a/geode-pulse/src/test/java/org/apache/geode/tools/pulse/tests/rules/WebDriverRule.java
+++ b/geode-pulse/src/test/java/org/apache/geode/tools/pulse/tests/rules/WebDriverRule.java
@@ -43,9 +43,9 @@ public class WebDriverRule extends ExternalResource {
   }
 
   public WebDriverRule(String username, String password, String pulseUrl) {
+    this(pulseUrl);
     this.username = username;
     this.password = password;
-    this.pulseUrl = pulseUrl;
   }
 
   public WebDriver getDriver() {
@@ -63,9 +63,7 @@ public class WebDriverRule extends ExternalResource {
 
   @Override
   protected void before() throws Throwable {
-    if (driver == null) {
-      setUpWebDriver();
-    }
+    setUpWebDriver();
     driver.get(getPulseURL());
     if (StringUtils.isNotBlank(username) && StringUtils.isNotBlank(password)) {
       login();
@@ -75,7 +73,7 @@ public class WebDriverRule extends ExternalResource {
 
   @Override
   protected void after() {
-    driver.close();
+    driver.quit();
   }
 
   private void login() {

--- a/geode-pulse/src/test/java/org/apache/geode/tools/pulse/tests/ui/PulseTestUtils.java
+++ b/geode-pulse/src/test/java/org/apache/geode/tools/pulse/tests/ui/PulseTestUtils.java
@@ -53,11 +53,11 @@ public final class PulseTestUtils {
     }
   }
 
-  public static int maxWaitTime = 20;
+  public static int maxWaitTime = 30;
 
   public static WebElement waitForElementWithId(String id) {
-    WebElement element =
-        (new WebDriverWait(driverProvider.get(), 10)).until(new ExpectedCondition<WebElement>() {
+    WebElement element = (new WebDriverWait(driverProvider.get(), maxWaitTime))
+        .until(new ExpectedCondition<WebElement>() {
           @Override
           public WebElement apply(WebDriver d) {
             return d.findElement(By.id(id));


### PR DESCRIPTION
- WebDriver gets closed properly so that the UITests don't overwhelm
 CI machines with extra processes
- Increase WebDriver element wait time to reduce test flakiness