### PR TITLE
[GEODE-224] Geode Spark connector parser is not processing type casting properly

### DIFF
--- a/geode-spark-connector/geode-spark-connector/src/main/scala/org/apache/geode/spark/connector/internal/oql/QueryParser.scala
+++ b/geode-spark-connector/geode-spark-connector/src/main/scala/org/apache/geode/spark/connector/internal/oql/QueryParser.scala
@@ -36,7 +36,7 @@ class QueryParser extends RegexParsers {
 
   def PACKAGE: Parser[String] = """[\w.]+""".r
 
-  def projection: Parser[String] = "*" | repsep("""["\w]+[.\w"]*""".r, ",") ^^ {
+  def projection: Parser[String] = "*" | repsep(opt("""\([A-Za-z]+\)""".r) ~> """["\w]+[.\w"]*""".r, ",") ^^ {
     _.toString
   }
 

--- a/geode-spark-connector/geode-spark-connector/src/test/scala/org/apache/geode/spark/connector/internal/oql/QueryParserTest.scala
+++ b/geode-spark-connector/geode-spark-connector/src/test/scala/org/apache/geode/spark/connector/internal/oql/QueryParserTest.scala
@@ -80,4 +80,14 @@ class QueryParserTest extends FunSuite {
     val r = QueryParser.parseOQL("SELECT r.id, r.\"type\", r.positions, r.status FROM /obj_obj_region r, r.positions.values f WHERE r.status = 'active' and f.secId = 'MSFT'").get
     assert(r == "List(/obj_obj_region, r.positions.values)")
   }
+
+  test("SELECT (Int)r.id, r.\"type\", (Double)r.positions, r.status FROM /obj_obj_region r, r.positions.values f WHERE r.status = 'active'") {
+    val r = QueryParser.parseOQL("SELECT (Int)r.id, r.\"type\", (Double)r.positions, r.status FROM /obj_obj_region r, r.positions.values f WHERE r.status = 'active'").get
+    assert(r == "List(/obj_obj_region, r.positions.values)")
+  }
+
+  test("SELECT distinct (Double)f1, (Float)f2 FROM /r1/r2 WHere f = 100") {
+    val r = QueryParser.parseOQL("SELECT distinct (Double)f1, (Float)f2 FROM /r1/r2 WHere f = 100").get
+    assert(r == "List(/r1/r2)")
+  }
 }


### PR DESCRIPTION
This issue is related to wrong regex of query string. 